### PR TITLE
Add immersive room example and timestamped art output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # liber-arcanae
-living tarot repo that connects to the other apps 
+living tarot repo that connects to the other apps
+
+## Examples
+
+- `visionary_dream.py` – generates a unique visionary art image saved with a timestamped filename.
+- `immersive_room.py` – demonstrates an exploratory room rendered with Pygame, including simple art and looping audio.

--- a/examples/immersive_room.py
+++ b/examples/immersive_room.py
@@ -1,0 +1,59 @@
+import os
+import math
+import numpy as np
+import pygame
+
+# Use a headless video driver if no display is available
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+# Initialize pygame modules and audio
+pygame.init()
+pygame.mixer.init(frequency=44100)
+
+# Screen dimensions for the exploratory room
+WIDTH, HEIGHT = 800, 600
+screen = pygame.display.set_mode((WIDTH, HEIGHT))
+pygame.display.set_caption("Immersive Creative Room")
+
+# Create a simple gradient background representing wall art
+background = pygame.Surface((WIDTH, HEIGHT))
+for y in range(HEIGHT):
+    color = (y * 255 // HEIGHT, 0, 128)
+    pygame.draw.line(background, color, (0, y), (WIDTH, y))
+
+# Generate a looping sine wave tone as placeholder music
+sample_rate = 44100
+seconds = 2
+samples = np.linspace(0, seconds, int(sample_rate * seconds), False)
+tone = (np.sin(2 * math.pi * 440 * samples) * 32767).astype(np.int16)
+sound = pygame.sndarray.make_sound(tone)
+sound.play(-1)
+
+# Avatar starting position
+x, y = WIDTH // 2, HEIGHT // 2
+clock = pygame.time.Clock()
+frames = 0
+running = True
+
+# Main exploration loop (auto-exits after ~2 seconds)
+while running and frames < 120:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            running = False
+    keys = pygame.key.get_pressed()
+    if keys[pygame.K_LEFT]:
+        x -= 5
+    if keys[pygame.K_RIGHT]:
+        x += 5
+    if keys[pygame.K_UP]:
+        y -= 5
+    if keys[pygame.K_DOWN]:
+        y += 5
+
+    screen.blit(background, (0, 0))
+    pygame.draw.circle(screen, (255, 255, 255), (x, y), 10)
+    pygame.display.flip()
+    clock.tick(60)
+    frames += 1
+
+pygame.quit()

--- a/examples/visionary_dream.py
+++ b/examples/visionary_dream.py
@@ -1,5 +1,6 @@
 import math
 import random
+from datetime import datetime
 from PIL import Image, ImageDraw
 
 # Set canvas dimensions (1920x1080)
@@ -46,5 +47,7 @@ for _ in range(300):
     color = random.choice(palette)
     draw.ellipse([x, y, x + 3, y + 3], fill=color)
 
-# Save the final visionary art piece
-canvas.save('Visionary_Dream.png')
+# Save the final visionary art piece with a unique timestamped name
+filename = f"Visionary_Dream_{datetime.now().strftime('%Y%m%d_%H%M%S')}.png"
+canvas.save(filename)
+print(f"Saved {filename}")


### PR DESCRIPTION
## Summary
- Save visionary_dream art pieces with a unique timestamped filename
- Introduce an immersive Pygame room example with basic art and looping audio
- Document examples in the README

## Testing
- `pip install pillow pygame numpy` *(fails: Cannot connect to proxy)*
- `python examples/visionary_dream.py` *(fails: No module named 'PIL')*
- `python examples/immersive_room.py` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68ba593f0ed48328a86abe7c547cc753