### PR TITLE
feat(renderer): add static cosmic helix canvas

### DIFF
--- a/cosmogenesis-learning-engine/README_RENDERER.md
+++ b/cosmogenesis-learning-engine/README_RENDERER.md
@@ -1,0 +1,20 @@
+# Cosmic Helix Renderer
+
+Static, offline-friendly canvas drawing that layers sacred geometry:
+Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static
+double-helix lattice. ND-safe: no motion, no autoplay, calm contrast.
+
+## Use
+- Download or clone this repo.
+- Double-click `index.html` in this folder.
+- A 1440×900 canvas will render the four layers in order.
+
+## Files
+- `index.html` – entry point; loads palette and draws.
+- `js/helix-renderer.mjs` – pure ES module with small functions.
+- `data/palette.json` – optional palette override; safe fallback built-in.
+
+## ND-safe Notes
+- No external network calls; works offline.
+- No animation; geometry renders once on load.
+- Soft colors and layer comments explain sensory choices.

--- a/cosmogenesis-learning-engine/data/palette.json
+++ b/cosmogenesis-learning-engine/data/palette.json
@@ -1,0 +1,5 @@
+{
+  "bg": "#0b0b12",
+  "ink": "#e8e8f0",
+  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+}

--- a/cosmogenesis-learning-engine/index.html
+++ b/cosmogenesis-learning-engine/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
+  </header>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || defaults.palette;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+  </script>
+</body>
+</html>

--- a/cosmogenesis-learning-engine/js/helix-renderer.mjs
+++ b/cosmogenesis-learning-engine/js/helix-renderer.mjs
@@ -1,0 +1,128 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers:
+    1) Vesica field (intersecting circles)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
+    3) Fibonacci curve (log spiral polyline; static)
+    4) Double-helix lattice (two phase-shifted sin curves)
+
+  No animation, no external deps. Geometry uses numerology constants
+  to keep proportions meaningful. All functions are pure and small.
+*/
+
+export function renderHelix(ctx, { width, height, palette, NUM }) {
+  ctx.save();
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0, 0, width, height);
+  ctx.translate(width / 2, height / 2); // center origin
+
+  drawVesica(ctx, width, height, palette.layers[0], NUM);
+  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
+  drawFibonacci(ctx, palette.layers[3], NUM);
+  drawDoubleHelix(ctx, width, height, palette.layers[4], palette.layers[5], NUM);
+
+  ctx.restore();
+}
+
+function drawVesica(ctx, width, height, color, NUM) {
+  // ND-safe: light grid of intersecting circles; static, gentle
+  const radius = Math.min(width, height) / NUM.TWENTYTWO;
+  const step = radius; // dense enough to suggest vesica field
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1;
+  for (let y = -height; y <= height; y += step) {
+    for (let x = -width; x <= width; x += step) {
+      ctx.beginPath();
+      ctx.arc(x, y, radius, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+}
+
+function drawTree(ctx, width, height, colorNode, colorPath, NUM) {
+  // Simplified Kircher layout; proportions tied to NUM constants
+  const scale = Math.min(width, height) / NUM.NINETYNINE;
+  const nodes = [
+    [0, -4], [2, -3], [-2, -3], [2, -1], [-2, -1],
+    [0, 0], [2, 1], [-2, 1], [0, 2], [0, 3]
+  ].map(([x, y]) => [x * scale * NUM.SEVEN, y * scale * NUM.SEVEN / NUM.ELEVEN]);
+
+  const paths = [
+    [0,1],[0,2],[1,2],[1,3],[2,4],[3,4],[3,5],[4,5],[3,6],[4,7],
+    [6,7],[6,8],[7,8],[6,9],[7,9],[8,9],[5,6],[5,7],[5,8],[1,5],
+    [2,5],[0,5]
+  ];
+
+  ctx.strokeStyle = colorPath;
+  ctx.lineWidth = 2;
+  for (const [a, b] of paths) {
+    ctx.beginPath();
+    ctx.moveTo(nodes[a][0], nodes[a][1]);
+    ctx.lineTo(nodes[b][0], nodes[b][1]);
+    ctx.stroke();
+  }
+
+  ctx.fillStyle = colorNode;
+  const r = scale * NUM.SEVEN / NUM.THIRTYTHREE;
+  for (const [x, y] of nodes) {
+    ctx.beginPath();
+    ctx.arc(x, y, r, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function drawFibonacci(ctx, color, NUM) {
+  // Log spiral approximated via polyline
+  const phi = (1 + Math.sqrt(5)) / 2;
+  const turns = NUM.ELEVEN; // gentle count
+  const step = Math.PI / NUM.SEVEN;
+  const scale = NUM.THIRTYTHREE; // base radius
+
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  for (let t = 0; t <= turns; t += step) {
+    const r = scale * Math.pow(phi, t / Math.PI);
+    const x = r * Math.cos(t);
+    const y = r * Math.sin(t);
+    if (t === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+}
+
+function drawDoubleHelix(ctx, width, height, colorA, colorB, NUM) {
+  // Static lattice of two sine waves phase-shifted by PI
+  const amp = height / NUM.NINE / 2;
+  const wave = width / NUM.TWENTYTWO;
+  const step = NUM.THREE; // fine grain
+
+  ctx.lineWidth = 1.5;
+  ctx.strokeStyle = colorA;
+  ctx.beginPath();
+  for (let x = -width / 2; x <= width / 2; x += step) {
+    const y = amp * Math.sin((x / wave) * Math.PI * 2);
+    if (x === -width / 2) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+
+  ctx.strokeStyle = colorB;
+  ctx.beginPath();
+  for (let x = -width / 2; x <= width / 2; x += step) {
+    const y = amp * Math.sin((x / wave) * Math.PI * 2 + Math.PI);
+    if (x === -width / 2) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+
+  // Lattice connectors
+  ctx.strokeStyle = colorA;
+  for (let x = -width / 2; x <= width / 2; x += wave) {
+    const y1 = amp * Math.sin((x / wave) * Math.PI * 2);
+    const y2 = amp * Math.sin((x / wave) * Math.PI * 2 + Math.PI);
+    ctx.beginPath();
+    ctx.moveTo(x, y1);
+    ctx.lineTo(x, y2);
+    ctx.stroke();
+  }
+}


### PR DESCRIPTION
## Summary
- add offline ND-safe cosmic helix renderer
- include palette config and geometry module
- document usage for static renderer

## Testing
- `node circuitum99/main/04_registry-meta/integrity-check.mjs` *(fails: Cannot find module)*
- `npm test` *(fails: ENOENT, missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8959b22c8328be563073b1083c63