### PR TITLE
feat(renderer): add static cosmic helix canvas

### DIFF
--- a/cosmogenesis-learning-engine/README_RENDERER.md
+++ b/cosmogenesis-learning-engine/README_RENDERER.md
@@ -1,0 +1,19 @@
+# Cosmic Helix Renderer
+
+Static, ND-safe HTML canvas that layers Vesica field, Tree-of-Life nodes, Fibonacci curve, and a double-helix lattice. Works offline: double-click `index.html`.
+
+## Files
+- `index.html` — entry point
+- `js/helix-renderer.mjs` — pure rendering logic
+- `data/palette.json` — optional palette override
+
+## Why
+- Calm palette, no motion, no autoplay
+- Geometry uses numerology constants (3,7,9,11,22,33,99,144)
+- Offline-first for trauma-informed use
+
+## Usage
+1. Open `index.html` directly in a browser
+2. Optional: edit `data/palette.json` to adjust colors
+
+No external dependencies or network requests.

--- a/cosmogenesis-learning-engine/data/palette.json
+++ b/cosmogenesis-learning-engine/data/palette.json
@@ -1,0 +1,5 @@
+{
+  "bg": "#0b0b12",
+  "ink": "#e8e8f0",
+  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+}

--- a/cosmogenesis-learning-engine/index.html
+++ b/cosmogenesis-learning-engine/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
+  </header>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || defaults.palette;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+  </script>
+</body>
+</html>

--- a/cosmogenesis-learning-engine/js/helix-renderer.mjs
+++ b/cosmogenesis-learning-engine/js/helix-renderer.mjs
@@ -1,0 +1,128 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers:
+    1) Vesica field (intersecting circles)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
+    3) Fibonacci curve (log spiral polyline; static)
+    4) Double-helix lattice (two phase-shifted sine waves)
+
+  All routines are pure and synchronous; no motion, no external deps.
+*/
+
+export function renderHelix(ctx, opts) {
+  const { width, height, palette, NUM } = opts;
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0, 0, width, height);
+  drawVesica(ctx, width, height, palette.layers[0], NUM);
+  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
+  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
+  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], NUM);
+}
+
+// Layer 1 — Vesica field
+function drawVesica(ctx, w, h, color, NUM) {
+  const r = w / NUM.THREE; // uses numerology constant 3
+  const offset = r / NUM.ELEVEN; // gentle overlap
+  const cy = h / 2;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.arc(w / 2 - offset, cy, r, 0, Math.PI * 2);
+  ctx.arc(w / 2 + offset, cy, r, 0, Math.PI * 2);
+  ctx.stroke();
+}
+
+// Layer 2 — Tree of Life
+function drawTree(ctx, w, h, nodeColor, edgeColor, NUM) {
+  const cx = w / 2;
+  const dx = w / NUM.SEVEN; // horizontal spacing
+  const dy = h / NUM.NINE; // vertical spacing
+  // simplified sephirot positions
+  const nodes = [
+    [cx, dy * 0.5],
+    [cx + dx, dy * 1.5],
+    [cx - dx, dy * 1.5],
+    [cx - dx, dy * 3],
+    [cx + dx, dy * 3],
+    [cx, dy * 4.5],
+    [cx - dx, dy * 6],
+    [cx + dx, dy * 6],
+    [cx, dy * 7.5],
+    [cx, dy * 9]
+  ];
+  const paths = [
+    [0,1],[0,2],[1,2],[1,3],[1,4],[2,3],[2,4],[3,4],
+    [3,5],[4,5],[3,6],[4,7],[5,6],[5,7],[5,8],[6,7],
+    [6,8],[7,8],[6,9],[7,9],[8,9],[1,5]
+  ];
+  ctx.strokeStyle = edgeColor;
+  for (const [a,b] of paths) {
+    const [ax,ay] = nodes[a];
+    const [bx,by] = nodes[b];
+    ctx.beginPath();
+    ctx.moveTo(ax, ay);
+    ctx.lineTo(bx, by);
+    ctx.stroke();
+  }
+  ctx.fillStyle = nodeColor;
+  for (const [x,y] of nodes) {
+    ctx.beginPath();
+    ctx.arc(x, y, w / NUM.TWENTYTWO, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+// Layer 3 — Fibonacci log spiral
+function drawFibonacci(ctx, w, h, color, NUM) {
+  const phi = (1 + Math.sqrt(5)) / 2;
+  const cx = w * 0.75;
+  const cy = h * 0.6;
+  const base = Math.min(w, h) / NUM.TWENTYTWO;
+  const pts = [];
+  for (let i = 0; i < NUM.ELEVEN; i++) { // 11 points
+    const theta = i * Math.PI / NUM.SEVEN; // gentle turn
+    const r = base * Math.pow(phi, i);
+    pts.push([cx + r * Math.cos(theta), cy + r * Math.sin(theta)]);
+  }
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(pts[0][0], pts[0][1]);
+  for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i][0], pts[i][1]);
+  ctx.stroke();
+}
+
+// Layer 4 — Double helix lattice
+function drawHelix(ctx, w, h, colorA, colorB, NUM) {
+  const steps = NUM.ONEFORTYFOUR; // sample count
+  const amp = w / NUM.NINE;
+  const cx = w / 2;
+  const ptsA = [];
+  const ptsB = [];
+  for (let i = 0; i <= steps; i++) {
+    const y = (h / steps) * i;
+    const t = i / NUM.THIRTYTHREE; // frequency scaling
+    ptsA.push([cx + Math.sin(t) * amp, y]);
+    ptsB.push([cx + Math.sin(t + Math.PI) * amp, y]);
+  }
+  ctx.strokeStyle = colorA;
+  ctx.beginPath();
+  ctx.moveTo(ptsA[0][0], ptsA[0][1]);
+  for (let i = 1; i < ptsA.length; i++) ctx.lineTo(ptsA[i][0], ptsA[i][1]);
+  ctx.stroke();
+  ctx.strokeStyle = colorB;
+  ctx.beginPath();
+  ctx.moveTo(ptsB[0][0], ptsB[0][1]);
+  for (let i = 1; i < ptsB.length; i++) ctx.lineTo(ptsB[i][0], ptsB[i][1]);
+  ctx.stroke();
+  // lattice rungs every 11th point
+  ctx.strokeStyle = colorB;
+  for (let i = 0; i < ptsA.length; i += NUM.ELEVEN) {
+    ctx.beginPath();
+    ctx.moveTo(ptsA[i][0], ptsA[i][1]);
+    ctx.lineTo(ptsB[i][0], ptsB[i][1]);
+    ctx.stroke();
+  }
+}


### PR DESCRIPTION
## Summary
- add offline ND-safe cosmic helix renderer HTML entry point
- implement pure ES module drawing vesica, tree nodes, fibonacci, and helix lattice
- include palette data and README usage notes

## Testing
- `node --check cosmogenesis-learning-engine/js/helix-renderer.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68ba88cb0b708328bc200089dc1dfe24