### PR TITLE
Add static ND-safe canvas renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,0 +1,22 @@
+# Cosmic Helix Renderer
+
+Static, offline HTML + Canvas renderer for layered sacred geometry.
+
+## Files
+- `index.html` — entry point; open directly without a server.
+- `js/helix-renderer.mjs` — ES module with pure drawing functions.
+- `data/palette.json` — optional palette override; delete to use built-in fallback.
+
+## Layers
+1. **Vesica field** — intersecting circles forming foundational geometry.
+2. **Tree-of-Life** — ten sephirot and twenty-two connecting paths.
+3. **Fibonacci curve** — logarithmic spiral honoring natural growth.
+4. **Double-helix lattice** — static twin sine links symbolizing duality.
+
+## ND-safe Notes
+- No motion or flashing; all elements render statically in layer order.
+- Palette uses gentle contrast for readability and reduced sensory load.
+- Geometry counts reference numerology constants (3,7,9,11,22,33,99,144).
+
+## Use
+Double-click `index.html` in any modern browser while offline. If `data/palette.json` is missing, the renderer notes this and applies a safe fallback palette.

--- a/data/palette.json
+++ b/data/palette.json
@@ -1,0 +1,5 @@
+{
+  "bg": "#0b0b12",
+  "ink": "#e8e8f0",
+  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
+  </header>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || defaults.palette;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+  </script>
+</body>
+</html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,0 +1,134 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers:
+    1) Vesica field (intersecting circles)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
+    3) Fibonacci curve (log spiral polyline; static)
+    4) Double-helix lattice (two phase-shifted sine links)
+*/
+
+// renderHelix orchestrates layer drawing; kept small for clarity
+export function renderHelix(ctx, opts) {
+  const { width, height, palette, NUM } = opts;
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0, 0, width, height);
+
+  drawVesica(ctx, width, height, palette.layers[0], NUM);
+  drawTree(ctx, width, height, palette.layers[1], NUM);
+  drawFibonacci(ctx, width, height, palette.layers[2], NUM);
+  drawHelix(ctx, width, height, palette.layers[3], NUM);
+}
+
+// Layer 1: Vesica field using a 3x3 grid (NUM.THREE)
+function drawVesica(ctx, w, h, color, NUM) {
+  const rows = NUM.THREE; // ND-safe: limited repetition avoids visual overload
+  const cols = NUM.THREE;
+  const r = Math.min(w / (cols * 2), h / (rows * 2));
+  const stepX = w / (cols + 1);
+  const stepY = h / (rows + 1);
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  for (let i = 1; i <= cols; i++) {
+    for (let j = 1; j <= rows; j++) {
+      const cx = i * stepX;
+      const cy = j * stepY;
+      ctx.beginPath();
+      ctx.arc(cx - r / 2, cy, r, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.arc(cx + r / 2, cy, r, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+}
+
+// Layer 2: Tree-of-Life scaffold with 10 nodes and 22 paths
+function drawTree(ctx, w, h, color, NUM) {
+  ctx.strokeStyle = color;
+  ctx.fillStyle = color;
+  ctx.lineWidth = 1;
+
+  const nodes = [
+    { x:0.5, y:0.05 }, // 1 Keter
+    { x:0.75, y:0.15 }, // 2 Chokmah
+    { x:0.25, y:0.15 }, // 3 Binah
+    { x:0.75, y:0.35 }, // 4 Chesed
+    { x:0.25, y:0.35 }, // 5 Gevurah
+    { x:0.5, y:0.45 }, // 6 Tiferet
+    { x:0.75, y:0.65 }, // 7 Netzach
+    { x:0.25, y:0.65 }, // 8 Hod
+    { x:0.5, y:0.75 }, // 9 Yesod
+    { x:0.5, y:0.9 }   //10 Malkuth
+  ];
+
+  const paths = [
+    [1,2],[1,3],[1,6],
+    [2,3],[2,4],[2,6],[2,7],
+    [3,5],[3,6],
+    [4,5],[4,6],[4,7],
+    [5,6],[5,8],
+    [6,8],[6,9],
+    [7,8],[7,9],[7,10],
+    [8,9],[8,10],
+    [9,10]
+  ]; // 22 paths honoring NUM.TWENTYTWO
+
+  // Draw paths
+  for (const [a, b] of paths) {
+    const A = nodes[a - 1];
+    const B = nodes[b - 1];
+    ctx.beginPath();
+    ctx.moveTo(A.x * w, A.y * h);
+    ctx.lineTo(B.x * w, B.y * h);
+    ctx.stroke();
+  }
+
+  // Draw nodes with radius tied to NUM.NINE
+  const r = NUM.NINE;
+  for (const n of nodes) {
+    ctx.beginPath();
+    ctx.arc(n.x * w, n.y * h, r, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+// Layer 3: Fibonacci spiral using 33 segments (NUM.THIRTYTHREE)
+function drawFibonacci(ctx, w, h, color, NUM) {
+  const cx = w / 2;
+  const cy = h / 2;
+  const golden = (1 + Math.sqrt(5)) / 2; // φ for growth ratio
+  const points = [];
+  const base = Math.min(w, h) / NUM.ONEFORTYFOUR; // 144 as scale anchor
+  for (let i = 0; i <= NUM.THIRTYTHREE; i++) {
+    const angle = i * (Math.PI / NUM.ELEVEN); // gentle turn
+    const r = base * Math.pow(golden, i / NUM.SEVEN);
+    points.push({ x: cx + r * Math.cos(angle), y: cy + r * Math.sin(angle) });
+  }
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(points[0].x, points[0].y);
+  for (const p of points.slice(1)) ctx.lineTo(p.x, p.y);
+  ctx.stroke();
+}
+
+// Layer 4: Static double-helix lattice with 144 vertical steps
+function drawHelix(ctx, w, h, color, NUM) {
+  const steps = NUM.ONEFORTYFOUR; // dense but still static
+  const amp = h / NUM.NINE; // amplitude tied to NUM.NINE
+  const mid = h / 2;
+  const stepX = w / steps;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1;
+  for (let i = 0; i <= steps; i++) {
+    const x = i * stepX;
+    const y1 = mid + amp * Math.sin(i / NUM.ELEVEN);
+    const y2 = mid + amp * Math.sin(i / NUM.ELEVEN + Math.PI);
+    ctx.beginPath();
+    ctx.moveTo(x, y1);
+    ctx.lineTo(x, y2);
+    ctx.stroke();
+  }
+}


### PR DESCRIPTION
## Summary
- add offline index.html using safe palette and numerology constants
- implement layered helix renderer ES module with vesica, tree-of-life, fibonacci spiral, and double helix lattice
- document usage and provide default palette

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba73ec330c832890214e84f602985c