### PR TITLE
docs: document offline requirements

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<!-- Offline-first: no external requests; open directly -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -26,12 +27,14 @@
   <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
 
   <script type="module">
+    // Offline-first renderer: imports local module only
     import { renderHelix } from "./js/helix-renderer.mjs";
 
     const elStatus = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
+    // Offline-first: fetch only attempts local palette file
     async function loadJSON(path) {
       try {
         const res = await fetch(path, { cache: "no-store" });

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -9,7 +9,7 @@
     4) Double-helix lattice (two phase-shifted sine strands with crossbars)
 
   All geometry is parameterized with numerology constants passed via NUM.
-  No animation, no network, calm palette.
+  Offline-first: no animation, no network requests, calm palette.
 */
 
 export function renderHelix(ctx, opts) {


### PR DESCRIPTION
## Summary
- document offline-only behavior in HTML and renderer module
- clarify that palette fetch is local only

## Testing
- `node` manual script verifying default palette when `palette.json` missing

------
https://chatgpt.com/codex/tasks/task_e_68bbe2fee3608328b9614a0d9a88d2e7