### PR TITLE
docs: clarify offline renderer usage

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,19 +1,22 @@
 # Cosmic Helix Renderer
 
-Static offline canvas showcasing layered sacred geometry.
+Static, offline sacred-geometry renderer.
 
 ## Layers
-1. **Vesica Field** – intersecting circles forming a calm grid.
-2. **Tree-of-Life Scaffold** – ten sephirot and twenty-two paths.
-3. **Fibonacci Curve** – logarithmic spiral derived from the golden ratio.
-4. **Double-Helix Lattice** – two phase-shifted strands with nine crossbars.
+1. Vesica field - intersecting circles forming a calm grid.
+2. Tree-of-Life scaffold - ten sephirot and twenty-two paths.
+3. Fibonacci curve - logarithmic spiral derived from the golden ratio.
+4. Double-helix lattice - two phase-shifted strands with nine crossbars.
 
 ## Usage
-- Open `index.html` directly in any modern browser.
-- Optional palette overrides live in `data/palette.json`.
-- No network calls; if the palette file is missing, safe defaults load.
+Double-click "index.html" in any modern browser.
+Optional palette overrides live in "data/palette.json".
+No network calls; if the palette file is missing, safe defaults load.
 
-## ND-Safe Choices
-- No motion or animation.
-- Soft contrast palette and generous spacing.
-- Pure functions, ES modules, UTF-8 LF encoding.
+## ND-safe design
+No motion or animation.
+Soft contrast palette and generous spacing.
+Pure functions, ES modules, UTF-8 LF encoding.
+
+## Numerology constants
+3, 7, 9, 11, 22, 33, 99, 144


### PR DESCRIPTION
## Summary
- clarify static sacred-geometry renderer purpose
- note double-click usage and ND-safe design
- document layers and numerology constants

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68bbe332bda48328b41b3b9086bba4ae