### PR TITLE
chore: replace nd-safe static helix renderer

### DIFF
--- a/data/palette.json
+++ b/data/palette.json
@@ -1,15 +1,5 @@
 {
-  "bg":"#0b0b12",
-  "ink":"#e8e8f0",
-  "layers":["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
   "bg": "#0b0b12",
   "ink": "#e8e8f0",
-  "layers": [
-    "#b1c7ff",
-    "#89f7fe",
-    "#a0ffa1",
-    "#ffd27f",
-    "#f5a3ff",
-    "#d0d0e6"
-  ]
+  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
 }

--- a/index.html
+++ b/index.html
@@ -8,17 +8,11 @@
   <style>
     /* ND-safe: calm contrast, no motion, generous spacing */
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
     header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
     .status { color:var(--muted); font-size:12px; }
     #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
     .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
-
-    .settings { margin-top:8px; display:flex; gap:16px; flex-wrap:wrap; }
-    .settings label { font-size:12px; display:flex; align-items:center; gap:4px; color:var(--muted); }
-    #settings { display:flex; gap:8px; margin-top:8px; flex-wrap:wrap; }
-    #settings label { font-size:12px; color:var(--muted); }
-    #settings select { margin-left:4px; }
     code { background:#11111a; padding:2px 4px; border-radius:3px; }
   </style>
 </head>
@@ -26,78 +20,30 @@
   <header>
     <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
     <div class="status" id="status">Loading palette…</div>
-    <form id="settings" class="settings" aria-label="Settings">
-      <label>Motion
-        <select name="motion">
-    <div id="settings" aria-label="safety settings">
-      <label>Motion
-        <select id="motion">
-          <option value="reduced" selected>Reduced</option>
-          <option value="full">Full</option>
-        </select>
-      </label>
-      <label>Contrast
-        <select name="contrast">
-      <label>Audio
-        <select id="audio">
-          <option value="off" selected>Off</option>
-          <option value="on">On</option>
-        </select>
-      </label>
-      <label>Contrast
-        <select id="contrast">
-          <option value="balanced" selected>Balanced</option>
-          <option value="high">High</option>
-        </select>
-      </label>
-      <label><input type="checkbox" name="autoplay"> Allow audio autoplay</label>
-    </form>
-    </div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
   <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
 
-  <script type="module" src="./index.js"></script>
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
-    import { Safety } from "./ui/safety.js";
 
     const elStatus = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
-    const form = document.getElementById("settings");
 
-    function applySettings(){
-      Safety.state.motion = form.motion.value;
-      Safety.state.contrast = form.contrast.value;
-      Safety.state.autoplay = form.autoplay.checked;
-      Safety.apply();
-    }
-    form.addEventListener("change", applySettings);
-    applySettings();
-    Safety.apply();
-
-    Safety.apply();
-    const motionSel = document.getElementById("motion");
-    const audioSel = document.getElementById("audio");
-    const contrastSel = document.getElementById("contrast");
-    for (const [sel, key] of [[motionSel,"motion"], [audioSel,"autoplay"], [contrastSel,"contrast"]]) {
-      sel.addEventListener("change", e => { Safety.state[key] = e.target.value; Safety.apply(); });
-    }
-
-    async function loadJSON(path){
-      try{
-        const res = await fetch(path, {cache:"no-store"});
-        if(!res.ok) throw new Error(String(res.status));
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
         return await res.json();
-      }catch(err){
-        return null;
+      } catch (err) {
+        return null; // ND-safe: if missing, caller falls back to defaults
       }
     }
 
     const defaults = {
-      palette:{
+      palette: {
         bg:"#0b0b12",
         ink:"#e8e8f0",
         layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
@@ -108,8 +54,11 @@
     const active = palette || defaults.palette;
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
-    const NUM = {THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144};
-    renderHelix(ctx, {width:canvas.width, height:canvas.height, palette:active, NUM});
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layer order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
   </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,70 +1,13 @@
 /*
   helix-renderer.mjs
   ND-safe static renderer for layered sacred geometry.
-
-
-  Layers:
-    1) Vesica field (intersecting circles)
-    2) Tree-of-Life scaffold (10 sephirot + 22 paths)
-    3) Fibonacci curve (log spiral polyline)
-    4) Double-helix lattice (two phase-shifted strands)
-
-  Rationale:
-    - No motion or autoplay; draws once in calm order.
-    - Gentle contrast palette avoids overstimulation.
-    - Small pure functions with explicit numerology.
-*/
-
-export function renderHelix(ctx, opts){
-  const {width, height, palette, NUM} = opts;
-  ctx.clearRect(0, 0, width, height);
-  ctx.fillStyle = palette.bg;
-  ctx.fillRect(0, 0, width, height);
-
-  drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTreeOfLife(ctx, width, height, palette.layers[1], NUM);
-  drawFibonacciCurve(ctx, width, height, palette.layers[2], NUM);
-  drawHelixLattice(ctx, width, height, palette.layers[3], NUM);
-}
-
-// Layer 1: Vesica field using 3x3 grid
-function drawVesica(ctx, w, h, color, NUM){
-  const cols = NUM.THREE;
-  const rows = NUM.THREE;
-  const r = Math.min(w, h) / NUM.NINE;
-  ctx.strokeStyle = color;
-  for(let j=0;j<rows;j++){
-    for(let i=0;i<cols;i++){
-      const cx = ((i+0.5)*w)/cols;
-      const cy = ((j+0.5)*h)/rows;
-      ctx.beginPath();
-      ctx.arc(cx - r/2, cy, r, 0, Math.PI*2);
-      ctx.arc(cx + r/2, cy, r, 0, Math.PI*2);
-      ctx.stroke();
-    }
-  }
-}
-
-// Layer 2: Tree-of-Life scaffold
-function drawTreeOfLife(ctx, w, h, color, NUM){
-  ctx.strokeStyle = color;
-  ctx.fillStyle = color;
-  const nodes = [
-    [0.5,0.05], [0.3,0.18], [0.7,0.18],
-    [0.3,0.35], [0.7,0.35], [0.5,0.5],
-    [0.3,0.65], [0.7,0.65], [0.5,0.8], [0.5,0.95]
-  ];
+  Why: supports offline study without motion or audio.
 
   Layers (drawn in order):
     1) Vesica field
     2) Tree-of-Life scaffold
     3) Fibonacci curve
-    4) Double-helix lattice
-
-  Rationale:
-    - No motion or autoplay; everything renders once.
-    - Soft contrast palette keeps focus gentle.
-    - Pure functions avoid hidden state.
+    4) Static double-helix lattice
 */
 
 export function renderHelix(ctx, opts) {
@@ -74,7 +17,7 @@ export function renderHelix(ctx, opts) {
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, width, height);
 
-  // Static layers rendered in a calm order
+  // Static layers rendered in calm order
   drawVesica(ctx, width, height, palette.layers[0], NUM);
   drawTreeOfLife(ctx, width, height, palette.layers[1], NUM);
   drawFibonacciCurve(ctx, width, height, palette.layers[2], NUM);
@@ -85,7 +28,7 @@ export function renderHelix(ctx, opts) {
 function drawVesica(ctx, w, h, color, NUM) {
   const cols = NUM.THREE;
   const rows = NUM.THREE;
-  const r = Math.min(w / (cols * 2), h / (rows * 2));
+  const r = Math.min(w, h) / NUM.NINE; // radius tied to NUM.NINE
   const stepX = w / (cols + 1);
   const stepY = h / (rows + 1);
   ctx.strokeStyle = color;
@@ -104,72 +47,38 @@ function drawVesica(ctx, w, h, color, NUM) {
   }
 }
 
-// Layer 2: Tree-of-Life scaffold with 10 nodes and 22 paths
+// Layer 2: Tree-of-Life scaffold with 10 nodes and 22 paths (NUM.TWENTYTWO)
 function drawTreeOfLife(ctx, w, h, color, NUM) {
   ctx.strokeStyle = color;
   ctx.fillStyle = color;
   ctx.lineWidth = 1;
 
+  // Node coordinates expressed as ratios for offline portability
   const nodes = [
-    [w / 2, h * 0.05],
-    [w * 0.3, h * 0.18],
-    [w * 0.7, h * 0.18],
-    [w * 0.3, h * 0.35],
-    [w * 0.7, h * 0.35],
-    [w / 2, h * 0.5],
-    [w * 0.3, h * 0.65],
-    [w * 0.7, h * 0.65],
-    [w / 2, h * 0.8],
-    [w / 2, h * 0.95]
+    [0.5, 0.05], [0.3, 0.18], [0.7, 0.18],
+    [0.3, 0.35], [0.7, 0.35], [0.5, 0.5],
+    [0.3, 0.65], [0.7, 0.65], [0.5, 0.8], [0.5, 0.95]
   ];
-
 
   const paths = [
     [0,1],[0,2],[1,2],[1,3],[2,4],[3,4],[3,5],[4,5],[3,6],[4,7],
     [5,6],[5,7],[6,7],[6,8],[7,8],[6,9],[7,9],[8,9],[1,5],[2,5],
     [0,5],[5,9]
-
-  ]; // 22 paths honoring NUM.TWENTYTWO
-  paths.forEach(([a,b])=>{
-    const A = nodes[a];
-    const B = nodes[b];
   ]; // 22 paths honouring NUM.TWENTYTWO
 
   for (const [a, b] of paths) {
     const [ax, ay] = nodes[a];
     const [bx, by] = nodes[b];
     ctx.beginPath();
-    ctx.moveTo(A[0]*w, A[1]*h);
-    ctx.lineTo(B[0]*w, B[1]*h);
+    ctx.moveTo(ax * w, ay * h);
+    ctx.lineTo(bx * w, by * h);
     ctx.stroke();
-  });
-  const r = NUM.NINE; // calm node radius
-  nodes.forEach(([x,y])=>{
-    ctx.beginPath();
-    ctx.arc(x*w, y*h, r, 0, Math.PI*2);
-    ctx.fill();
-  });
-}
-
-// Layer 3: Fibonacci curve
-function drawFibonacciCurve(ctx, w, h, color, NUM){
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const center = {x:w*0.75, y:h*0.3};
-  ctx.strokeStyle = color;
-  ctx.beginPath();
-  for(let i=0;i<=NUM.THIRTYTHREE;i++){
-    const theta = i*(Math.PI/NUM.SEVEN);
-    const r = Math.pow(phi, theta);
-    const x = center.x + r*Math.cos(theta);
-    const y = center.y + r*Math.sin(theta);
-    if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
-=======
   }
 
-  const r = NUM.THREE; // gentle node size
+  const r = Math.min(w, h) / NUM.NINETYNINE; // small node radius
   for (const [x, y] of nodes) {
     ctx.beginPath();
-    ctx.arc(x, y, r, 0, Math.PI * 2);
+    ctx.arc(x * w, y * h, r, 0, Math.PI * 2);
     ctx.fill();
   }
 }
@@ -187,22 +96,10 @@ function drawFibonacciCurve(ctx, w, h, color, NUM) {
     const x = center.x + r * Math.cos(theta);
     const y = center.y + r * Math.sin(theta);
     if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-
   }
   ctx.stroke();
 }
 
-
-// Layer 4: Double-helix lattice
-function drawHelixLattice(ctx, w, h, color, NUM){
-  const steps = NUM.ONEFORTYFOUR;
-  const amp = h/NUM.NINE;
-  const mid = h/2;
-  ctx.strokeStyle = color;
-  for(let i=0;i<=steps;i++){
-    const x = (i/steps)*w;
-    const y1 = mid + amp*Math.sin(i/NUM.ELEVEN);
-    const y2 = mid + amp*Math.sin(i/NUM.ELEVEN + Math.PI);
 // Layer 4: Static double-helix lattice
 function drawHelixLattice(ctx, w, h, colorA, colorB, NUM) {
   const steps = NUM.ONEFORTYFOUR; // 144 vertical steps
@@ -221,20 +118,23 @@ function drawHelixLattice(ctx, w, h, colorA, colorB, NUM) {
     if (idx === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   });
   ctx.stroke();
+
   ctx.strokeStyle = colorB;
   ctx.beginPath();
   strandB.forEach(([x, y], idx) => {
     if (idx === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   });
   ctx.stroke();
-  ctx.strokeStyle = colorB; // crossbars
+
+  // crossbars every NUM.NINE steps
+  ctx.strokeStyle = colorB;
   const barStep = Math.floor(steps / NUM.NINE);
   for (let i = 0; i <= steps; i += barStep) {
     const [x1, y1] = strandA[i];
     const [x2, y2] = strandB[i];
     ctx.beginPath();
-    ctx.moveTo(x, y1);
-    ctx.lineTo(x, y2);
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(x2, y2);
     ctx.stroke();
   }
 }


### PR DESCRIPTION
## Summary
- simplify index.html for offline cosmic helix renderer with palette fallback
- clean helix-renderer module using numerology constants and static layers
- restore valid palette JSON for ND-safe swatch

## Testing
- `npm test` *(fails: SyntaxError in tests/interface.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bcdf6a0ba88328a6af6d7865eef883