### PR TITLE
Clean static renderer and offline utilities

### DIFF
--- a/data/palette.json
+++ b/data/palette.json
@@ -1,15 +1,5 @@
 {
-  "bg":"#0b0b12",
-  "ink":"#e8e8f0",
-  "layers":["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
   "bg": "#0b0b12",
   "ink": "#e8e8f0",
-  "layers": [
-    "#b1c7ff",
-    "#89f7fe",
-    "#a0ffa1",
-    "#ffd27f",
-    "#f5a3ff",
-    "#d0d0e6"
-  ]
+  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
 }

--- a/engines/interface-guard.js
+++ b/engines/interface-guard.js
@@ -1,33 +1,16 @@
-
-
-// Validates incoming JSON against minimal interface schema; soft-fail to protect runtime.
-
+/*
+  interface-guard.js
+  Offline validator for shared interface shapes.
+  ND-safe: avoids network requests and fails softly.
+*/
 
 export async function validateInterface(payload, schemaUrl="/assets/data/interface.schema.json"){
   try{
-    const [schema, AjvMod] = await Promise.all([
-      fetch(schemaUrl).then(r=>r.json()),
-
-
-      import("https://cdn.skypack.dev/ajv@8?min").catch(()=>null)
-    ]);
-    if(AjvMod){
-      const ajv = new AjvMod.default({allErrors:true, strict:false});
-      const valid = ajv.validate(schema, payload);
-      return {valid, errors: ajv.errors||[]};
-    }
+    const schema = await fetch(schemaUrl, {cache:"no-store"}).then(r=>r.json());
     const req = schema.required || [];
-    const missing = req.filter(k=>!(k in payload));
-    return {valid:missing.length===0, errors:missing.map(m=>({message:`missing ${m}`}))};
+    const missing = req.filter(k => !(k in payload));
+    return {valid: missing.length === 0, errors: missing.map(m => ({message:`missing ${m}`}))};
   }catch(e){
     return {valid:false, errors:[{message:e.message}]};
   }
-
-
-      import("https://cdn.skypack.dev/ajv@8?min")
-    ]);
-    const ajv = new AjvMod.default({allErrors:true, strict:false});
-    const valid = ajv.validate(schema, payload);
-    return {valid, errors: ajv.errors||[]};
-  }catch(e){ return {valid:false, errors:[{message:e.message}]}; }
 }

--- a/engines/registry-loader.js
+++ b/engines/registry-loader.js
@@ -1,12 +1,8 @@
-
-// Loads registry.json from current repo, then resolves relative repo paths.
-// On iPad/Safari: use fetch for local paths served by dev server.
-export async function loadRegistry(url="/assets/data/registry.json"){
-  const res = await fetch(url, {cache:"no-store"});
-  if(!res.ok) throw new Error("Registry not found: "+url);
-  const reg = await res.json();
-  return reg;
-
+/*
+  registry-loader.js
+  Loads registry.json describing nearby repos.
+  ND-safe: uses fetch without side effects.
+*/
 
 export async function loadRegistry(url="/assets/data/registry.json"){
   const res = await fetch(url, {cache:"no-store"});

--- a/index.html
+++ b/index.html
@@ -13,12 +13,6 @@
     .status { color:var(--muted); font-size:12px; }
     #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
     .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
-
-    .settings { margin-top:8px; display:flex; gap:16px; flex-wrap:wrap; }
-    .settings label { font-size:12px; display:flex; align-items:center; gap:4px; color:var(--muted); }
-    #settings { display:flex; gap:8px; margin-top:8px; flex-wrap:wrap; }
-    #settings label { font-size:12px; color:var(--muted); }
-    #settings select { margin-left:4px; }
     code { background:#11111a; padding:2px 4px; border-radius:3px; }
   </style>
 </head>
@@ -26,78 +20,30 @@
   <header>
     <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
     <div class="status" id="status">Loading palette…</div>
-    <form id="settings" class="settings" aria-label="Settings">
-      <label>Motion
-        <select name="motion">
-    <div id="settings" aria-label="safety settings">
-      <label>Motion
-        <select id="motion">
-          <option value="reduced" selected>Reduced</option>
-          <option value="full">Full</option>
-        </select>
-      </label>
-      <label>Contrast
-        <select name="contrast">
-      <label>Audio
-        <select id="audio">
-          <option value="off" selected>Off</option>
-          <option value="on">On</option>
-        </select>
-      </label>
-      <label>Contrast
-        <select id="contrast">
-          <option value="balanced" selected>Balanced</option>
-          <option value="high">High</option>
-        </select>
-      </label>
-      <label><input type="checkbox" name="autoplay"> Allow audio autoplay</label>
-    </form>
-    </div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
   <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
 
-  <script type="module" src="./index.js"></script>
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
-    import { Safety } from "./ui/safety.js";
 
     const elStatus = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
-    const form = document.getElementById("settings");
 
-    function applySettings(){
-      Safety.state.motion = form.motion.value;
-      Safety.state.contrast = form.contrast.value;
-      Safety.state.autoplay = form.autoplay.checked;
-      Safety.apply();
-    }
-    form.addEventListener("change", applySettings);
-    applySettings();
-    Safety.apply();
-
-    Safety.apply();
-    const motionSel = document.getElementById("motion");
-    const audioSel = document.getElementById("audio");
-    const contrastSel = document.getElementById("contrast");
-    for (const [sel, key] of [[motionSel,"motion"], [audioSel,"autoplay"], [contrastSel,"contrast"]]) {
-      sel.addEventListener("change", e => { Safety.state[key] = e.target.value; Safety.apply(); });
-    }
-
-    async function loadJSON(path){
-      try{
-        const res = await fetch(path, {cache:"no-store"});
-        if(!res.ok) throw new Error(String(res.status));
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
         return await res.json();
-      }catch(err){
+      } catch (err) {
         return null;
       }
     }
 
     const defaults = {
-      palette:{
+      palette: {
         bg:"#0b0b12",
         ink:"#e8e8f0",
         layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
@@ -108,8 +54,11 @@
     const active = palette || defaults.palette;
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
-    const NUM = {THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144};
-    renderHelix(ctx, {width:canvas.width, height:canvas.height, palette:active, NUM});
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
   </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -2,7 +2,6 @@
   helix-renderer.mjs
   ND-safe static renderer for layered sacred geometry.
 
-
   Layers:
     1) Vesica field (intersecting circles)
     2) Tree-of-Life scaffold (10 sephirot + 22 paths)
@@ -12,69 +11,15 @@
   Rationale:
     - No motion or autoplay; draws once in calm order.
     - Gentle contrast palette avoids overstimulation.
-    - Small pure functions with explicit numerology.
-*/
-
-export function renderHelix(ctx, opts){
-  const {width, height, palette, NUM} = opts;
-  ctx.clearRect(0, 0, width, height);
-  ctx.fillStyle = palette.bg;
-  ctx.fillRect(0, 0, width, height);
-
-  drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTreeOfLife(ctx, width, height, palette.layers[1], NUM);
-  drawFibonacciCurve(ctx, width, height, palette.layers[2], NUM);
-  drawHelixLattice(ctx, width, height, palette.layers[3], NUM);
-}
-
-// Layer 1: Vesica field using 3x3 grid
-function drawVesica(ctx, w, h, color, NUM){
-  const cols = NUM.THREE;
-  const rows = NUM.THREE;
-  const r = Math.min(w, h) / NUM.NINE;
-  ctx.strokeStyle = color;
-  for(let j=0;j<rows;j++){
-    for(let i=0;i<cols;i++){
-      const cx = ((i+0.5)*w)/cols;
-      const cy = ((j+0.5)*h)/rows;
-      ctx.beginPath();
-      ctx.arc(cx - r/2, cy, r, 0, Math.PI*2);
-      ctx.arc(cx + r/2, cy, r, 0, Math.PI*2);
-      ctx.stroke();
-    }
-  }
-}
-
-// Layer 2: Tree-of-Life scaffold
-function drawTreeOfLife(ctx, w, h, color, NUM){
-  ctx.strokeStyle = color;
-  ctx.fillStyle = color;
-  const nodes = [
-    [0.5,0.05], [0.3,0.18], [0.7,0.18],
-    [0.3,0.35], [0.7,0.35], [0.5,0.5],
-    [0.3,0.65], [0.7,0.65], [0.5,0.8], [0.5,0.95]
-  ];
-
-  Layers (drawn in order):
-    1) Vesica field
-    2) Tree-of-Life scaffold
-    3) Fibonacci curve
-    4) Double-helix lattice
-
-  Rationale:
-    - No motion or autoplay; everything renders once.
-    - Soft contrast palette keeps focus gentle.
-    - Pure functions avoid hidden state.
+    - Small pure functions with explicit numerology constants.
 */
 
 export function renderHelix(ctx, opts) {
   const { width, height, palette, NUM } = opts;
   ctx.clearRect(0, 0, width, height);
-  // ND-safe: fill background first to avoid flashes
-  ctx.fillStyle = palette.bg;
+  ctx.fillStyle = palette.bg; // ND-safe: fill background first
   ctx.fillRect(0, 0, width, height);
 
-  // Static layers rendered in a calm order
   drawVesica(ctx, width, height, palette.layers[0], NUM);
   drawTreeOfLife(ctx, width, height, palette.layers[1], NUM);
   drawFibonacciCurve(ctx, width, height, palette.layers[2], NUM);
@@ -123,50 +68,22 @@ function drawTreeOfLife(ctx, w, h, color, NUM) {
     [w / 2, h * 0.95]
   ];
 
-
   const paths = [
-    [0,1],[0,2],[1,2],[1,3],[2,4],[3,4],[3,5],[4,5],[3,6],[4,7],
-    [5,6],[5,7],[6,7],[6,8],[7,8],[6,9],[7,9],[8,9],[1,5],[2,5],
-    [0,5],[5,9]
-
-  ]; // 22 paths honoring NUM.TWENTYTWO
-  paths.forEach(([a,b])=>{
-    const A = nodes[a];
-    const B = nodes[b];
-  ]; // 22 paths honouring NUM.TWENTYTWO
+    [0,1],[0,2],[1,2],[1,3],[2,4],[3,4],[3,5],[4,5],
+    [3,6],[4,7],[5,6],[5,7],[6,7],[6,8],[7,8],[6,9],
+    [7,9],[8,9],[1,5],[2,5],[0,5],[5,9]
+  ]; // NUM.TWENTYTWO
 
   for (const [a, b] of paths) {
     const [ax, ay] = nodes[a];
     const [bx, by] = nodes[b];
     ctx.beginPath();
-    ctx.moveTo(A[0]*w, A[1]*h);
-    ctx.lineTo(B[0]*w, B[1]*h);
+    ctx.moveTo(ax, ay);
+    ctx.lineTo(bx, by);
     ctx.stroke();
-  });
-  const r = NUM.NINE; // calm node radius
-  nodes.forEach(([x,y])=>{
-    ctx.beginPath();
-    ctx.arc(x*w, y*h, r, 0, Math.PI*2);
-    ctx.fill();
-  });
-}
-
-// Layer 3: Fibonacci curve
-function drawFibonacciCurve(ctx, w, h, color, NUM){
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const center = {x:w*0.75, y:h*0.3};
-  ctx.strokeStyle = color;
-  ctx.beginPath();
-  for(let i=0;i<=NUM.THIRTYTHREE;i++){
-    const theta = i*(Math.PI/NUM.SEVEN);
-    const r = Math.pow(phi, theta);
-    const x = center.x + r*Math.cos(theta);
-    const y = center.y + r*Math.sin(theta);
-    if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
-=======
   }
 
-  const r = NUM.THREE; // gentle node size
+  const r = NUM.NINE; // calm node radius
   for (const [x, y] of nodes) {
     ctx.beginPath();
     ctx.arc(x, y, r, 0, Math.PI * 2);
@@ -187,25 +104,13 @@ function drawFibonacciCurve(ctx, w, h, color, NUM) {
     const x = center.x + r * Math.cos(theta);
     const y = center.y + r * Math.sin(theta);
     if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-
   }
   ctx.stroke();
 }
 
-
-// Layer 4: Double-helix lattice
-function drawHelixLattice(ctx, w, h, color, NUM){
-  const steps = NUM.ONEFORTYFOUR;
-  const amp = h/NUM.NINE;
-  const mid = h/2;
-  ctx.strokeStyle = color;
-  for(let i=0;i<=steps;i++){
-    const x = (i/steps)*w;
-    const y1 = mid + amp*Math.sin(i/NUM.ELEVEN);
-    const y2 = mid + amp*Math.sin(i/NUM.ELEVEN + Math.PI);
 // Layer 4: Static double-helix lattice
 function drawHelixLattice(ctx, w, h, colorA, colorB, NUM) {
-  const steps = NUM.ONEFORTYFOUR; // 144 vertical steps
+  const steps = NUM.ONEFORTYFOUR;
   const amp = h / NUM.NINE;
   const mid = h / 2;
   const strandA = [];
@@ -217,15 +122,11 @@ function drawHelixLattice(ctx, w, h, colorA, colorB, NUM) {
   }
   ctx.strokeStyle = colorA;
   ctx.beginPath();
-  strandA.forEach(([x, y], idx) => {
-    if (idx === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  });
+  strandA.forEach(([x, y], idx) => { if (idx === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y); });
   ctx.stroke();
   ctx.strokeStyle = colorB;
   ctx.beginPath();
-  strandB.forEach(([x, y], idx) => {
-    if (idx === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  });
+  strandB.forEach(([x, y], idx) => { if (idx === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y); });
   ctx.stroke();
   ctx.strokeStyle = colorB; // crossbars
   const barStep = Math.floor(steps / NUM.NINE);
@@ -233,8 +134,8 @@ function drawHelixLattice(ctx, w, h, colorA, colorB, NUM) {
     const [x1, y1] = strandA[i];
     const [x2, y2] = strandB[i];
     ctx.beginPath();
-    ctx.moveTo(x, y1);
-    ctx.lineTo(x, y2);
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(x2, y2);
     ctx.stroke();
   }
 }

--- a/tests/interface.test.js
+++ b/tests/interface.test.js
@@ -1,22 +1,11 @@
-import {validateInterface} from "../engines/interface-guard.js";
+import { validateInterface } from "../engines/interface-guard.js";
+import { readFile } from "node:fs/promises";
 
-import {readFile} from "node:fs/promises";
-import path from "node:path";
-import {fileURLToPath} from "node:url";
-
-(async ()=>{
-  const __dirname = path.dirname(fileURLToPath(import.meta.url));
-  const samplePath = path.resolve(__dirname, "../assets/data/sample_interface.json");
-  const sample = JSON.parse(await readFile(samplePath, "utf8"));
-  const res = await validateInterface(sample, "http://localhost:8080/assets/data/interface.schema.json");
-
-import {readFile} from "fs/promises";
-
-(async ()=>{
+(async () => {
   const schemaText = await readFile(new URL("../assets/data/interface.schema.json", import.meta.url), "utf8");
   const schemaUrl = "data:application/json," + encodeURIComponent(schemaText);
   const sample = JSON.parse(await readFile(new URL("../assets/data/sample_interface.json", import.meta.url), "utf8"));
   const res = await validateInterface(sample, schemaUrl);
-  if(!res.valid){ throw new Error("Interface schema failed: "+JSON.stringify(res.errors)); }
+  if (!res.valid) { throw new Error("Interface schema failed: " + JSON.stringify(res.errors)); }
   console.log("Interface schema OK");
 })();


### PR DESCRIPTION
## Summary
- Rebuild static ND-safe index.html with palette fallback and numerology constants
- Rewrite helix-renderer module and palette data for calm layered geometry
- Simplify interface validator, registry loader, and schema test for offline safety

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcc59c3e0083289f97fdf0737af511