### PR TITLE
Clean sacred renderer comment markers

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,4 +1,4 @@
-Per Texturas Numerorum, Spira Loquitur.  //
+Per Texturas Numerorum, Spira Loquitur.
 
 # Cosmic Helix Renderer
 

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!-- Per Texturas Numerorum, Spira Loquitur.  // -->
+<!-- Per Texturas Numerorum, Spira Loquitur. -->
 <!doctype html>
 <html lang="en">
 <head>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,4 +1,4 @@
-// Per Texturas Numerorum, Spira Loquitur.  //
+// Per Texturas Numerorum, Spira Loquitur.
 /*
   helix-renderer.mjs
   ND-safe static renderer for layered sacred geometry.


### PR DESCRIPTION
## Summary
- remove stray `//` artifacts from renderer motto across HTML, JS, and docs

## Testing
- `node --check js/helix-renderer.mjs`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4fcbd52dc832880095c42467dc7ba