### PR TITLE
Integrate cosmic helix renderer into main atlas

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -28,11 +28,11 @@ Geometry routines in this renderer reference sacred numbers 3, 7, 9, 11, 22, 33,
 ## Local Use
 Double-click [index.html](./index.html) in any modern browser. The 1440×900 canvas renders immediately with no network calls.
 The renderer depends on [`js/helix-renderer.mjs`](./js/helix-renderer.mjs) and optional [`data/palette.json`](./data/palette.json).
-Everything runs offline.
+Everything runs offline. The Pantheon atlas at the top of the page remains intact; the helix canvas sits beneath the node catalogue and shares the Calm Mode toggle for consistent softening.
 
 ## ND-safe Notes
 - No motion or flashing; all elements render statically in layer order.
-- Palette uses gentle contrast for readability, with Calm Mode softening hues when toggled or when the OS requests reduced motion.
+- Palette uses gentle contrast for readability, with Calm Mode softening hues when toggled or when the OS requests reduced motion. Status text clarifies when fallbacks are engaged.
 - Skip link, `<main>` landmark, and status messaging keep the page navigable by keyboard and assistive tech.
 - Pure functions, ES modules, UTF-8, and LF newlines.
 - Palette file can be edited offline to adjust hues; the page falls back to built-in colors if it's missing and surfaces a small inline notice.

--- a/index.html
+++ b/index.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>Liber Arcanae Pantheon Atlas</title>
@@ -42,66 +41,79 @@
       </div>
       <div id="node-list" class="node-list" role="list"></div>
     </section>
+    <section class="cosmic-helix" aria-labelledby="helix-heading">
+      <div class="cosmic-head">
+        <h2 id="helix-heading">Cosmic Helix Renderer</h2>
+        <p class="status-line" id="helix-status" role="status" aria-live="polite">Preparing helix layers…</p>
+      </div>
+      <canvas id="helix-stage" width="1440" height="900" aria-label="Layered sacred geometry canvas" role="img">
+        Your browser does not support canvas. The helix lattice requires a modern browser.
+      </canvas>
+      <p class="cosmic-note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
+    </section>
   </main>
   <footer class="site-footer">
     <p>Service worker keeps the atlas offline-first; manifest icons cover 192 and 512 requirements.</p>
   </footer>
   <script type="module">
     import { initNodeGallery } from './js/loadNodes.js';
+    import { renderHelix } from './js/helix-renderer.mjs';
 
-    const statusEl = document.querySelector('[data-status]');
-    const listEl = document.getElementById('node-list');
+    const nodeStatusEl = document.querySelector('[data-status]');
+    const nodeListEl = document.getElementById('node-list');
     const calmToggle = document.getElementById('calm-toggle');
     const calmLabel = calmToggle.querySelector('.calm-toggle__label');
-    const storageKey = 'liber-arcanae.calm-mode';
+    const helixCanvas = document.getElementById('helix-stage');
+    const helixStatus = document.getElementById('helix-status');
+    const helixCtx = helixCanvas ? helixCanvas.getContext('2d') : null;
 
+    const storageKey = 'liber-arcanae.calm-mode';
     const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
 
-    const getStoredPreference = () => {
-      try {
-        return window.localStorage.getItem(storageKey);
-      } catch (error) {
-        console.warn('localStorage unavailable, calm mode defaults only.', error);
-        return null;
+    const defaults = {
+      palette: {
+        bg: '#0b0b12',
+        ink: '#e8e8f0',
+        layers: ['#b1c7ff', '#89f7fe', '#a0ffa1', '#ffd27f', '#f5a3ff', '#d0d0e6']
       }
     };
 
-    const setStoredPreference = (value) => {
-      try {
-        window.localStorage.setItem(storageKey, value);
-      } catch (error) {
-        console.warn('Unable to persist calm mode preference.', error);
-      }
+    const NUM = {
+      THREE: 3,
+      SEVEN: 7,
+      NINE: 9,
+      ELEVEN: 11,
+      TWENTYTWO: 22,
+      THIRTYTHREE: 33,
+      NINETYNINE: 99,
+      ONEFORTYFOUR: 144
     };
 
-    const syncCalmState = (active) => {
-      calmToggle.setAttribute('aria-pressed', active ? 'true' : 'false');
-      calmLabel.textContent = active ? 'Calm mode on' : 'Calm mode off';
-    };
+    let paletteActive = clonePalette(defaults.palette);
+    let paletteCalm = createCalmPalette(paletteActive);
+    let paletteMessage = 'Preparing palette…';
+    let calmActive = false;
+    let manualOverride = false;
+
+    initNodeGallery({ listEl: nodeListEl, statusEl: nodeStatusEl });
 
     const storedPreference = getStoredPreference();
     const startCalm = storedPreference === 'on' || (storedPreference === null && mql.matches);
-    if (startCalm) {
-      document.body.classList.add('calm-mode');
-    }
-    syncCalmState(document.body.classList.contains('calm-mode'));
+    manualOverride = storedPreference !== null;
+    applyCalmState(startCalm, storedPreference !== null ? 'stored' : 'preference');
 
     calmToggle.addEventListener('click', () => {
-      const active = document.body.classList.toggle('calm-mode');
-      syncCalmState(active);
-      setStoredPreference(active ? 'on' : 'off');
+      const nextState = !calmActive;
+      manualOverride = nextState !== mql.matches;
+      applyCalmState(nextState, manualOverride ? 'manual' : 'sync');
+      setStoredPreference(nextState ? 'on' : 'off');
     });
 
     const handleMotionChange = (event) => {
-      if (getStoredPreference() !== null) {
-        return;
+      if (manualOverride) {
+        return; // Respect user override per ND-safe covenant
       }
-      if (event.matches) {
-        document.body.classList.add('calm-mode');
-      } else {
-        document.body.classList.remove('calm-mode');
-      }
-      syncCalmState(document.body.classList.contains('calm-mode'));
+      applyCalmState(event.matches, 'preference');
     };
 
     if (typeof mql.addEventListener === 'function') {
@@ -110,7 +122,11 @@
       mql.addListener(handleMotionChange);
     }
 
-    initNodeGallery({ listEl, statusEl });
+    if (helixCtx) {
+      prepareHelixPalette();
+    } else {
+      helixStatus.textContent = 'Canvas context unavailable; helix lattice cannot render in this browser.';
+    }
 
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {
@@ -118,118 +134,108 @@
           console.warn('Service worker registration failed:', error);
         });
       });
-
-  <meta charset="utf-8">
-  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
-  <meta name="color-scheme" content="light dark">
-  <style>
-    /* ND-safe: calm contrast, no motion, generous spacing */
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; --outline:#1d1d2a; }
-    body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
-    body.calm-mode { --bg:#080812; --ink:#f3f3fa; --muted:#c0c0dd; --outline:#27273c; }
-    a { color:inherit; }
-    .skip-link { position:absolute; left:-999px; top:auto; width:1px; height:1px; overflow:hidden; }
-    .skip-link:focus { left:16px; top:12px; width:auto; height:auto; padding:8px 12px; background:#1d1d2a; color:#f0f0ff; border-radius:6px; z-index:1000; text-decoration:none; }
-    header { padding:12px 16px; border-bottom:1px solid var(--outline); display:flex; flex-direction:column; gap:8px; }
-    .header-title { margin:0; font-size:16px; font-weight:600; }
-    .controls { display:flex; flex-wrap:wrap; align-items:center; gap:12px; }
-    .status { color:var(--muted); font-size:12px; }
-    .calm-button { border:1px solid var(--outline); background:transparent; color:var(--ink); padding:6px 12px; border-radius:6px; font:inherit; cursor:pointer; }
-    .calm-button:hover,.calm-button:focus-visible { border-color:var(--muted); outline:none; }
-    .calm-button[aria-pressed="true"] { background:rgba(45,45,70,0.35); }
-    .calm-button:disabled { opacity:0.6; cursor:not-allowed; }
-    main { padding:16px; display:flex; flex-direction:column; align-items:center; gap:16px; }
-    #stage { display:block; margin:0 auto; box-shadow:0 0 0 1px var(--outline); background:var(--bg); }
-    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
-    code { background:#11111a; padding:2px 4px; border-radius:3px; }
-  </style>
-</head>
-<body>
-  <a class="skip-link" href="#main">Skip to content</a>
-  <header>
-    <h1 class="header-title">Cosmic Helix Renderer — layered sacred geometry (offline, ND-safe)</h1>
-    <div class="controls">
-      <button type="button" id="calm-toggle" class="calm-button" aria-pressed="false">Calm Mode</button>
-      <span class="status" id="status" role="status" aria-live="polite">Loading palette…</span>
-    </div>
-  </header>
-
-  <main id="main">
-    <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas" role="img"></canvas>
-    <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
-  </main>
-
-  <script type="module">
-    import { renderHelix } from "./js/helix-renderer.mjs";
-
-    const elStatus = document.getElementById("status");
-    const canvas = document.getElementById("stage");
-    const calmToggle = document.getElementById("calm-toggle");
-    const ctx = canvas.getContext("2d");
-    const body = document.body;
-
-    const defaults = {
-      palette: {
-        bg:"#0b0b12",
-        ink:"#e8e8f0",
-        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      }
-    };
-
-    const NUM = {
-      THREE:3,
-      SEVEN:7,
-      NINE:9,
-      ELEVEN:11,
-      TWENTYTWO:22,
-      THIRTYTHREE:33,
-      NINETYNINE:99,
-      ONEFORTYFOUR:144
-    };
-
-    if (!ctx) {
-      elStatus.textContent = "Canvas context unavailable; static illustration cannot render.";
-      calmToggle.disabled = true;
-      calmToggle.setAttribute("aria-disabled", "true");
-    } else {
-      setupRenderer();
     }
 
-    async function setupRenderer() {
-      const paletteData = await loadJSON("./data/palette.json");
-      const palette = sanitizePalette(paletteData, defaults.palette);
-      const paletteMessage = paletteData ? "Palette loaded." : "Palette missing; using safe fallback.";
-      const palettes = { active: palette, calm: createCalmPalette(palette) };
-      const calmState = createCalmState({
-        body,
-        button: calmToggle,
-        statusEl: elStatus,
-        ctx,
-        canvas,
-        palettes,
-        baseMessage: paletteMessage,
+    async function prepareHelixPalette() {
+      const data = await loadJSON('./data/palette.json');
+      if (data) {
+        paletteActive = sanitizePalette(data, defaults.palette);
+        paletteMessage = 'Palette loaded.';
+      } else {
+        paletteActive = clonePalette(defaults.palette);
+        paletteMessage = 'Palette missing; using safe fallback.';
+      }
+      paletteCalm = createCalmPalette(paletteActive);
+      updateHelixStatus('palette');
+      renderHelixLayer();
+    }
+
+    function applyCalmState(active, source) {
+      calmActive = active;
+      document.body.classList.toggle('calm-mode', active);
+      syncCalmState(active);
+      updateHelixStatus(source);
+      renderHelixLayer();
+    }
+
+    function syncCalmState(active) {
+      calmToggle.setAttribute('aria-pressed', active ? 'true' : 'false');
+      calmLabel.textContent = active ? 'Calm mode on' : 'Calm mode off';
+    }
+
+    function renderHelixLayer() {
+      if (!helixCtx) {
+        return;
+      }
+      const palette = calmActive ? paletteCalm : paletteActive;
+      // ND-safe: render once with ordered layers, no motion or flashing
+      renderHelix(helixCtx, {
+        width: helixCanvas.width,
+        height: helixCanvas.height,
+        palette,
         NUM
       });
-      calmState.init();
+    }
+
+    function updateHelixStatus(source) {
+      if (!helixStatus) {
+        return;
+      }
+      if (!helixCtx) {
+        helixStatus.textContent = 'Canvas context unavailable; helix lattice cannot render in this browser.';
+        return;
+      }
+      const calmNote = calmActive ? ' Calm Mode active for softened hues.' : ' Calm Mode off for full contrast.';
+      let origin = '';
+      if (source === 'manual') {
+        origin = ' Manual override engaged.';
+      } else if (source === 'sync') {
+        origin = ' Manual override cleared; synced with system preference.';
+      } else if (source === 'preference') {
+        origin = ' Honoring system calm preference.';
+      } else if (source === 'stored') {
+        origin = ' Restored from saved preference.';
+      } else if (source === 'palette') {
+        origin = ' Palette refreshed.';
+      }
+      helixStatus.textContent = paletteMessage + calmNote + origin;
+    }
+
+    function getStoredPreference() {
+      try {
+        return window.localStorage.getItem(storageKey);
+      } catch (error) {
+        console.warn('localStorage unavailable, calm mode defaults only.', error);
+        return null;
+      }
+    }
+
+    function setStoredPreference(value) {
+      try {
+        window.localStorage.setItem(storageKey, value);
+      } catch (error) {
+        console.warn('Unable to persist calm mode preference.', error);
+      }
     }
 
     async function loadJSON(path) {
       try {
-        const res = await fetch(path, { cache:"no-store" });
+        const res = await fetch(path, { cache: 'no-store' });
         if (!res.ok) throw new Error(String(res.status));
         return await res.json();
-      } catch (err) {
-        return null; // Offline-first: fall back quietly
+      } catch (error) {
+        return null; // Offline-first: fall back quietly when palette file is absent
       }
     }
 
     function sanitizePalette(input, fallback) {
-      if (!input || typeof input !== "object") return clonePalette(fallback);
+      if (!input || typeof input !== 'object') {
+        return clonePalette(fallback);
+      }
       const safe = {
-        bg:isHex(input.bg) ? input.bg : fallback.bg,
-        ink:isHex(input.ink) ? input.ink : fallback.ink,
-        layers:Array.isArray(input.layers) ? input.layers.filter(isHex) : []
+        bg: isHex(input.bg) ? input.bg : fallback.bg,
+        ink: isHex(input.ink) ? input.ink : fallback.ink,
+        layers: Array.isArray(input.layers) ? input.layers.filter(isHex) : []
       };
       const needed = fallback.layers.length;
       while (safe.layers.length < needed) {
@@ -240,68 +246,20 @@
     }
 
     function clonePalette(palette) {
-      return { bg:palette.bg, ink:palette.ink, layers:palette.layers.slice() };
+      return { bg: palette.bg, ink: palette.ink, layers: palette.layers.slice() };
     }
 
     function createCalmPalette(base) {
-      // ND-safe: soften hues without removing contrast
+      // ND-safe: soften hues without removing contrast hierarchy
       return {
-        bg:mixHex(base.bg, base.ink, 0.08),
-        ink:base.ink,
-        layers:base.layers.map(layer => mixHex(layer, base.ink, 0.25))
+        bg: mixHex(base.bg, base.ink, 0.08),
+        ink: base.ink,
+        layers: base.layers.map((layer) => mixHex(layer, base.ink, 0.25))
       };
-    }
-
-    function createCalmState({ body, button, statusEl, ctx, canvas, palettes, baseMessage, NUM }) {
-      let calmActive = false;
-      let manualOverride = false;
-      const media = typeof window.matchMedia === "function"
-        ? window.matchMedia("(prefers-reduced-motion: reduce)")
-        : { matches:false };
-
-      const apply = (state, source) => {
-        calmActive = state;
-        body.classList.toggle("calm-mode", state);
-        button.setAttribute("aria-pressed", state ? "true" : "false");
-        const calmNote = state ? " Calm Mode active for softer palette." : " Calm Mode ready (toggle for softer palette).";
-        let origin = "";
-        if (source === "manual") origin = " Manual override engaged.";
-        if (source === "sync") origin = " Manual override cleared; synced with system preference.";
-        if (source === "preference" && state) origin = " Honoring system calm preference.";
-        statusEl.textContent = baseMessage + calmNote + origin;
-        renderHelix(ctx, {
-          width:canvas.width,
-          height:canvas.height,
-          palette: state ? palettes.calm : palettes.active,
-          NUM
-        });
-      };
-
-      const handlePreference = event => {
-        if (manualOverride) return; // Respect user toggle
-        apply(event.matches, "preference");
-      };
-
-      const init = () => {
-        apply(media.matches, "preference");
-        button.addEventListener("click", () => {
-          const nextState = !calmActive;
-          manualOverride = nextState !== media.matches;
-          const source = manualOverride ? "manual" : "sync";
-          apply(nextState, source);
-        });
-        if (typeof media.addEventListener === "function") {
-          media.addEventListener("change", handlePreference);
-        } else if (typeof media.addListener === "function") {
-          media.addListener(handlePreference);
-        }
-      };
-
-      return { init };
     }
 
     function isHex(value) {
-      return typeof value === "string" && /^#[0-9a-fA-F]{6}$/.test(value);
+      return typeof value === 'string' && /^#[0-9a-fA-F]{6}$/.test(value);
     }
 
     function mixHex(hexA, hexB, weight) {
@@ -309,28 +267,27 @@
       const b = hexToRgb(hexB);
       const w = clamp(weight, 0, 1);
       const blended = {
-        r:Math.round(a.r * (1 - w) + b.r * w),
-        g:Math.round(a.g * (1 - w) + b.g * w),
-        b:Math.round(a.b * (1 - w) + b.b * w)
+        r: Math.round(a.r * (1 - w) + b.r * w),
+        g: Math.round(a.g * (1 - w) + b.g * w),
+        b: Math.round(a.b * (1 - w) + b.b * w)
       };
       return rgbToHex(blended);
     }
 
     function hexToRgb(hex) {
-      const clean = hex.replace("#", "");
+      const clean = hex.replace('#', '');
       const r = parseInt(clean.slice(0, 2), 16);
       const g = parseInt(clean.slice(2, 4), 16);
       const b = parseInt(clean.slice(4, 6), 16);
-      return { r:Number.isNaN(r) ? 0 : r, g:Number.isNaN(g) ? 0 : g, b:Number.isNaN(b) ? 0 : b };
+      return { r: Number.isNaN(r) ? 0 : r, g: Number.isNaN(g) ? 0 : g, b: Number.isNaN(b) ? 0 : b };
     }
 
     function rgbToHex({ r, g, b }) {
-      return "#" + [r, g, b].map(v => clamp(v, 0, 255).toString(16).padStart(2, "0")).join("");
+      return '#' + [r, g, b].map((value) => clamp(value, 0, 255).toString(16).padStart(2, '0')).join('');
     }
 
     function clamp(value, min, max) {
       return Math.min(Math.max(value, min), max);
-
     }
   </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -144,6 +144,45 @@ main {
   box-shadow: 0 10px 40px rgba(10, 6, 20, 0.45);
 }
 
+.cosmic-helix {
+  margin-top: 3rem;
+  background: rgba(14, 9, 24, 0.72);
+  border: 1px solid var(--card-border);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  box-shadow: 0 10px 40px rgba(10, 6, 20, 0.45);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.cosmic-head {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+#helix-stage {
+  width: min(100%, 960px);
+  height: auto;
+  aspect-ratio: 1440 / 900;
+  display: block;
+  border-radius: 1rem;
+  box-shadow: 0 0 0 1px rgba(159, 143, 225, 0.3), 0 25px 45px rgba(9, 6, 18, 0.5);
+  background: radial-gradient(circle at top, rgba(38, 26, 62, 0.65), rgba(14, 9, 24, 0.9));
+}
+
+.cosmic-note {
+  margin: 0;
+  max-width: 60ch;
+  text-align: center;
+  color: var(--ink-soft);
+}
+
 .catalogue-head {
   display: flex;
   flex-wrap: wrap;
@@ -269,6 +308,15 @@ main {
 
 .calm-mode .catalogue {
   background: rgba(14, 9, 21, 0.8);
+}
+
+.calm-mode .cosmic-helix {
+  background: rgba(11, 7, 18, 0.85);
+}
+
+.calm-mode #helix-stage {
+  box-shadow: 0 0 0 1px rgba(122, 106, 189, 0.35);
+  background: radial-gradient(circle at top, rgba(35, 24, 58, 0.6), rgba(11, 7, 18, 0.9));
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- embed the Cosmic Helix canvas below the Pantheon catalogue while keeping the existing calm toggle
- extend the inline module script to load palettes, render static geometry, and surface ND-safe fallback messaging
- style the helix section for calm contrast and document the shared Calm Mode integration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd05f1e55c8328a520ec2def45a059

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a Cosmic Helix section with a canvas display and real-time status indicator.
  - Added offline-friendly palette loading with safe fallbacks.
  - Implemented Calm Mode with manual override, system preference sync, and persistent settings.

- Improvements
  - Enhanced accessibility and clearer status messages for palette loading and calm-state changes.
  - Increased robustness of color handling and rendering readiness checks.

- Style
  - Added a new “cosmic-helix” card with refined visuals, helix stage styling, and Calm Mode theming.

- Documentation
  - Updated offline behavior and Calm Mode descriptions, noting when fallbacks are active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->