### PR TITLE
Refine offline helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -2,38 +2,26 @@ Per Texturas Numerorum, Spira Loquitur.
 
 # Cosmic Helix Renderer
 
-Static, ND-safe HTML5 canvas renderer for layered sacred geometry. Open [index.html](./index.html) directly in a browser; no build steps or network requests.
+Static, ND-safe HTML5 canvas renderer for layered sacred geometry. Open [index.html](./index.html) directly in any modern browser; no build tools, servers, or workflows are required.
 
-## Layers
-1. **Vesica field** – intersecting circles laid out with the constant 3.
-2. **Tree-of-Life** – ten sephirot with twenty-two connecting paths.
-3. **Fibonacci curve** – fixed logarithmic spiral honoring natural growth.
-4. **Double-helix lattice** – two phase-shifted strands with calm crossbars.
+## Layer Order (depth preserved)
+1. **Vesica field** — intersecting circles on a triadic grid.
+2. **Tree-of-Life scaffold** — ten sephirot with twenty-two connecting paths.
+3. **Fibonacci curve** — fixed logarithmic spiral honoring natural growth.
+4. **Double-helix lattice** — two phase-shifted strands bound by calm crossbars.
 
-Each layer uses the next color from [`data/palette.json`](./data/palette.json). If the palette file is missing, a safe fallback loads and a small notice appears.
+Each layer draws with the next tone from [`data/palette.json`](./data/palette.json). If that file is absent, the page reports a gentle inline notice and renders with a built-in fallback palette so the geometry remains visible.
 
-## Numerology as Spiral Grammar
-The constants of the Cathedral are Fibonacci-coded checkpoints rather than flat decoration:
+## Numerology as Geometry Grammar
+The routines respect the requested constants: **3**, **7**, **9**, **11**, **22**, **33**, **99**, and **144**. They govern grid counts, spacing, and sample steps so the output stays faithful to the Cathedral canon while remaining static.
 
-- **21 pillars** – a Fibonacci node (8 + 13) aligning to Tarot majors and 21 Taras.
-- **33 spine** – triple elevens forming the Christic ladder.
-- **72 Shem angels/demons** – lunar decan cycle (8 × 9).
-- **78 archetypes** – complete Tarot weave (22 + 56).
-- **99 gates** – threefold expansion of the spine (3 × 33).
-- **144 lattice** – perfect square of 12 and 8th Fibonacci.
-- **243 completion** – fivefold power of the triad (3⁵).
+## Local Use (offline)
+1. Double-click [index.html](./index.html).
+2. The 1440×900 canvas renders immediately, pulling data only from local files.
+3. Optional: adjust hues in [`data/palette.json`](./data/palette.json) while keeping six calm tones (`bg`, `ink`, and four-or-more `layers`).
 
-Geometry routines in this renderer reference sacred numbers 3, 7, 9, 11, 22, 33, 99, and 144 to keep proportions meaningful while staying static.
-
-## Local Use
-Double-click [index.html](./index.html) in any modern browser. The 1440×900 canvas renders immediately with no network calls.
-The renderer depends on [`js/helix-renderer.mjs`](./js/helix-renderer.mjs) and optional [`data/palette.json`](./data/palette.json).
-Everything runs offline.
-
-## ND-safe Notes
-- No motion or flashing; all elements render statically in layer order.
-- Palette uses gentle contrast for readability, with Calm Mode softening hues when toggled or when the OS requests reduced motion.
-- Skip link, `<main>` landmark, and status messaging keep the page navigable by keyboard and assistive tech.
-- Pure functions, ES modules, UTF-8, and LF newlines.
-- Palette file can be edited offline to adjust hues; the page falls back to built-in colors if it's missing and surfaces a small inline notice.
-
+## ND-safe Guarantees
+- No animation, autoplay, flashes, or motion scripting—`renderHelix` runs once per load.
+- Gentle contrast palette with clear outlines; fallback stays within the same tonal family.
+- Inline comments document why layer order, numerology, and calm defaults are preserved.
+- Pure ES modules, ASCII quotes, UTF-8, LF newlines, and small focused functions.

--- a/index.html
+++ b/index.html
@@ -1,181 +1,76 @@
 <!doctype html>
 <html lang="en">
 <head>
-
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <title>Liber Arcanae Pantheon Atlas</title>
-  <meta name="description" content="Offline-first pantheon atlas for Codex 144:99 with ND-safe calm mode controls.">
-  <link rel="canonical" href="https://liber-arcanae.local/app/">
-  <meta name="theme-color" content="#6c5ba7">
-  <link rel="manifest" href="manifest.webmanifest">
-  <link rel="icon" type="image/png" sizes="192x192" href="img/icons/icon-192.png">
-  <link rel="icon" type="image/png" sizes="512x512" href="img/icons/icon-512.png">
-  <link rel="stylesheet" href="style.css">
-</head>
-<body>
-  <a class="skip-link" href="#main">Skip to content</a>
-  <header class="site-header" role="banner">
-    <div class="site-identity">
-      <h1>Liber Arcanae Pantheon Atlas</h1>
-      <p>Layered geometry and tarot research channels held within Codex 144:99 for offline study.</p>
-    </div>
-    <button id="calm-toggle" class="calm-toggle" type="button" aria-pressed="false" aria-describedby="calm-note">
-      <span class="calm-toggle__label">Calm mode off</span>
-    </button>
-  </header>
-  <p id="calm-note" class="visually-hidden">Calm mode softens color contrast and disables motion for ND-safe review.</p>
-  <main id="main" tabindex="-1">
-    <section class="hero" aria-labelledby="hero-heading">
-      <div class="hero-media">
-        <img src="img/black-madonna.webp" alt="Aurora gate gradient evoking Leonora Carrington constellations." loading="lazy" decoding="async" width="720" height="450">
-      </div>
-      <div class="hero-copy">
-        <h2 id="hero-heading">Aurora Gate Research Anchor</h2>
-        <p>This calm field is a grounded stand-in when Git LFS art is unavailable offline. It keeps the palette below 200 KB and honors the covenant&apos;s layered geometry request.</p>
-      </div>
-    </section>
-    <section class="catalogue" aria-labelledby="pantheon-heading">
-      <div class="catalogue-head">
-        <h2 id="pantheon-heading">Pantheon Node Catalogue</h2>
-        <p class="status-line" data-status role="status" aria-live="polite">Preparing node stream…</p>
-      </div>
-      <div id="node-list" class="node-list" role="list"></div>
-    </section>
-  </main>
-  <footer class="site-footer">
-    <p>Service worker keeps the atlas offline-first; manifest icons cover 192 and 512 requirements.</p>
-  </footer>
-  <script type="module">
-    import { initNodeGallery } from './js/loadNodes.js';
-
-    const statusEl = document.querySelector('[data-status]');
-    const listEl = document.getElementById('node-list');
-    const calmToggle = document.getElementById('calm-toggle');
-    const calmLabel = calmToggle.querySelector('.calm-toggle__label');
-    const storageKey = 'liber-arcanae.calm-mode';
-
-    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
-
-    const getStoredPreference = () => {
-      try {
-        return window.localStorage.getItem(storageKey);
-      } catch (error) {
-        console.warn('localStorage unavailable, calm mode defaults only.', error);
-        return null;
-      }
-    };
-
-    const setStoredPreference = (value) => {
-      try {
-        window.localStorage.setItem(storageKey, value);
-      } catch (error) {
-        console.warn('Unable to persist calm mode preference.', error);
-      }
-    };
-
-    const syncCalmState = (active) => {
-      calmToggle.setAttribute('aria-pressed', active ? 'true' : 'false');
-      calmLabel.textContent = active ? 'Calm mode on' : 'Calm mode off';
-    };
-
-    const storedPreference = getStoredPreference();
-    const startCalm = storedPreference === 'on' || (storedPreference === null && mql.matches);
-    if (startCalm) {
-      document.body.classList.add('calm-mode');
-    }
-    syncCalmState(document.body.classList.contains('calm-mode'));
-
-    calmToggle.addEventListener('click', () => {
-      const active = document.body.classList.toggle('calm-mode');
-      syncCalmState(active);
-      setStoredPreference(active ? 'on' : 'off');
-    });
-
-    const handleMotionChange = (event) => {
-      if (getStoredPreference() !== null) {
-        return;
-      }
-      if (event.matches) {
-        document.body.classList.add('calm-mode');
-      } else {
-        document.body.classList.remove('calm-mode');
-      }
-      syncCalmState(document.body.classList.contains('calm-mode'));
-    };
-
-    if (typeof mql.addEventListener === 'function') {
-      mql.addEventListener('change', handleMotionChange);
-    } else if (typeof mql.addListener === 'function') {
-      mql.addListener(handleMotionChange);
-    }
-
-    initNodeGallery({ listEl, statusEl });
-
-    if ('serviceWorker' in navigator) {
-      window.addEventListener('load', () => {
-        navigator.serviceWorker.register('./service-worker.js').catch((error) => {
-          console.warn('Service worker registration failed:', error);
-        });
-      });
-
   <meta charset="utf-8">
   <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="color-scheme" content="light dark">
   <style>
-    /* ND-safe: calm contrast, no motion, generous spacing */
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; --outline:#1d1d2a; }
-    body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
-    body.calm-mode { --bg:#080812; --ink:#f3f3fa; --muted:#c0c0dd; --outline:#27273c; }
-    a { color:inherit; }
-    .skip-link { position:absolute; left:-999px; top:auto; width:1px; height:1px; overflow:hidden; }
-    .skip-link:focus { left:16px; top:12px; width:auto; height:auto; padding:8px 12px; background:#1d1d2a; color:#f0f0ff; border-radius:6px; z-index:1000; text-decoration:none; }
-    header { padding:12px 16px; border-bottom:1px solid var(--outline); display:flex; flex-direction:column; gap:8px; }
-    .header-title { margin:0; font-size:16px; font-weight:600; }
-    .controls { display:flex; flex-wrap:wrap; align-items:center; gap:12px; }
-    .status { color:var(--muted); font-size:12px; }
-    .calm-button { border:1px solid var(--outline); background:transparent; color:var(--ink); padding:6px 12px; border-radius:6px; font:inherit; cursor:pointer; }
-    .calm-button:hover,.calm-button:focus-visible { border-color:var(--muted); outline:none; }
-    .calm-button[aria-pressed="true"] { background:rgba(45,45,70,0.35); }
-    .calm-button:disabled { opacity:0.6; cursor:not-allowed; }
+    /* ND-safe: gentle contrast, no motion, ample breathing room */
+    :root {
+      --bg:#0b0b12;
+      --ink:#e8e8f0;
+      --muted:#a6a6c1;
+      --outline:#1d1d2a;
+    }
+    *,*::before,*::after { box-sizing:border-box; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
+    header { padding:16px; border-bottom:1px solid var(--outline); }
+    .title { margin:0 0 4px; font-size:18px; font-weight:600; }
+    .status { font-size:12px; color:var(--muted); }
     main { padding:16px; display:flex; flex-direction:column; align-items:center; gap:16px; }
-    #stage { display:block; margin:0 auto; box-shadow:0 0 0 1px var(--outline); background:var(--bg); }
-    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
-    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+    #stage { display:block; width:1440px; height:900px; max-width:100%; box-shadow:0 0 0 1px var(--outline); background:var(--bg); }
+    .note { max-width:920px; color:var(--muted); margin:0 auto; text-align:center; }
+    @media (max-width:1500px) {
+      #stage { width:100%; height:auto; }
+    }
   </style>
 </head>
 <body>
-  <a class="skip-link" href="#main">Skip to content</a>
   <header>
-    <h1 class="header-title">Cosmic Helix Renderer — layered sacred geometry (offline, ND-safe)</h1>
-    <div class="controls">
-      <button type="button" id="calm-toggle" class="calm-button" aria-pressed="false">Calm Mode</button>
-      <span class="status" id="status" role="status" aria-live="polite">Loading palette…</span>
-    </div>
+    <h1 class="title">Cosmic Helix Renderer — layered sacred geometry (offline)</h1>
+    <p class="status" id="status" role="status" aria-live="polite">Loading palette…</p>
   </header>
-
-  <main id="main">
-    <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas" role="img"></canvas>
-    <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
+  <main>
+    <canvas id="stage" width="1440" height="900" role="img" aria-label="Vesica grid, Tree-of-Life, Fibonacci curve, and helix lattice"></canvas>
+    <p class="note">This static, offline canvas honors vesica piscis harmonics, Tree-of-Life scaffolding, Fibonacci unfolding, and a calm double-helix lattice. No animation, no network calls, just pure layered geometry.</p>
   </main>
-
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-    const elStatus = document.getElementById("status");
+    const statusEl = document.getElementById("status");
     const canvas = document.getElementById("stage");
-    const calmToggle = document.getElementById("calm-toggle");
     const ctx = canvas.getContext("2d");
-    const body = document.body;
+
+    async function loadPalette(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (error) {
+        return null;
+      }
+    }
 
     const defaults = {
-      palette: {
-        bg:"#0b0b12",
-        ink:"#e8e8f0",
-        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      }
+      bg: "#0b0b12",
+      ink: "#e8e8f0",
+      layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
     };
+
+    const palette = await loadPalette("./data/palette.json");
+    const active = palette || defaults;
+
+    if (palette) {
+      statusEl.textContent = "Palette loaded.";
+    } else {
+      statusEl.textContent = "Palette missing; using safe fallback.";
+    }
+
+    // Align CSS custom properties so the full page reflects the palette
+    const root = document.documentElement.style;
+    root.setProperty("--bg", active.bg);
+    root.setProperty("--ink", active.ink);
 
     const NUM = {
       THREE:3,
@@ -188,150 +83,8 @@
       ONEFORTYFOUR:144
     };
 
-    if (!ctx) {
-      elStatus.textContent = "Canvas context unavailable; static illustration cannot render.";
-      calmToggle.disabled = true;
-      calmToggle.setAttribute("aria-disabled", "true");
-    } else {
-      setupRenderer();
-    }
-
-    async function setupRenderer() {
-      const paletteData = await loadJSON("./data/palette.json");
-      const palette = sanitizePalette(paletteData, defaults.palette);
-      const paletteMessage = paletteData ? "Palette loaded." : "Palette missing; using safe fallback.";
-      const palettes = { active: palette, calm: createCalmPalette(palette) };
-      const calmState = createCalmState({
-        body,
-        button: calmToggle,
-        statusEl: elStatus,
-        ctx,
-        canvas,
-        palettes,
-        baseMessage: paletteMessage,
-        NUM
-      });
-      calmState.init();
-    }
-
-    async function loadJSON(path) {
-      try {
-        const res = await fetch(path, { cache:"no-store" });
-        if (!res.ok) throw new Error(String(res.status));
-        return await res.json();
-      } catch (err) {
-        return null; // Offline-first: fall back quietly
-      }
-    }
-
-    function sanitizePalette(input, fallback) {
-      if (!input || typeof input !== "object") return clonePalette(fallback);
-      const safe = {
-        bg:isHex(input.bg) ? input.bg : fallback.bg,
-        ink:isHex(input.ink) ? input.ink : fallback.ink,
-        layers:Array.isArray(input.layers) ? input.layers.filter(isHex) : []
-      };
-      const needed = fallback.layers.length;
-      while (safe.layers.length < needed) {
-        safe.layers.push(fallback.layers[safe.layers.length % fallback.layers.length]);
-      }
-      safe.layers = safe.layers.slice(0, needed);
-      return safe;
-    }
-
-    function clonePalette(palette) {
-      return { bg:palette.bg, ink:palette.ink, layers:palette.layers.slice() };
-    }
-
-    function createCalmPalette(base) {
-      // ND-safe: soften hues without removing contrast
-      return {
-        bg:mixHex(base.bg, base.ink, 0.08),
-        ink:base.ink,
-        layers:base.layers.map(layer => mixHex(layer, base.ink, 0.25))
-      };
-    }
-
-    function createCalmState({ body, button, statusEl, ctx, canvas, palettes, baseMessage, NUM }) {
-      let calmActive = false;
-      let manualOverride = false;
-      const media = typeof window.matchMedia === "function"
-        ? window.matchMedia("(prefers-reduced-motion: reduce)")
-        : { matches:false };
-
-      const apply = (state, source) => {
-        calmActive = state;
-        body.classList.toggle("calm-mode", state);
-        button.setAttribute("aria-pressed", state ? "true" : "false");
-        const calmNote = state ? " Calm Mode active for softer palette." : " Calm Mode ready (toggle for softer palette).";
-        let origin = "";
-        if (source === "manual") origin = " Manual override engaged.";
-        if (source === "sync") origin = " Manual override cleared; synced with system preference.";
-        if (source === "preference" && state) origin = " Honoring system calm preference.";
-        statusEl.textContent = baseMessage + calmNote + origin;
-        renderHelix(ctx, {
-          width:canvas.width,
-          height:canvas.height,
-          palette: state ? palettes.calm : palettes.active,
-          NUM
-        });
-      };
-
-      const handlePreference = event => {
-        if (manualOverride) return; // Respect user toggle
-        apply(event.matches, "preference");
-      };
-
-      const init = () => {
-        apply(media.matches, "preference");
-        button.addEventListener("click", () => {
-          const nextState = !calmActive;
-          manualOverride = nextState !== media.matches;
-          const source = manualOverride ? "manual" : "sync";
-          apply(nextState, source);
-        });
-        if (typeof media.addEventListener === "function") {
-          media.addEventListener("change", handlePreference);
-        } else if (typeof media.addListener === "function") {
-          media.addListener(handlePreference);
-        }
-      };
-
-      return { init };
-    }
-
-    function isHex(value) {
-      return typeof value === "string" && /^#[0-9a-fA-F]{6}$/.test(value);
-    }
-
-    function mixHex(hexA, hexB, weight) {
-      const a = hexToRgb(hexA);
-      const b = hexToRgb(hexB);
-      const w = clamp(weight, 0, 1);
-      const blended = {
-        r:Math.round(a.r * (1 - w) + b.r * w),
-        g:Math.round(a.g * (1 - w) + b.g * w),
-        b:Math.round(a.b * (1 - w) + b.b * w)
-      };
-      return rgbToHex(blended);
-    }
-
-    function hexToRgb(hex) {
-      const clean = hex.replace("#", "");
-      const r = parseInt(clean.slice(0, 2), 16);
-      const g = parseInt(clean.slice(2, 4), 16);
-      const b = parseInt(clean.slice(4, 6), 16);
-      return { r:Number.isNaN(r) ? 0 : r, g:Number.isNaN(g) ? 0 : g, b:Number.isNaN(b) ? 0 : b };
-    }
-
-    function rgbToHex({ r, g, b }) {
-      return "#" + [r, g, b].map(v => clamp(v, 0, 255).toString(16).padStart(2, "0")).join("");
-    }
-
-    function clamp(value, min, max) {
-      return Math.min(Math.max(value, min), max);
-
-    }
+    // ND-safe: single render pass, no motion
+    renderHelix(ctx, { width: canvas.width, height: canvas.height, palette: active, NUM });
   </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -17,16 +17,32 @@
 
 export function renderHelix(ctx, opts) {
   const { width, height, palette, NUM } = opts;
+  const layerColors = normalizeLayers(palette);
+  const background = (palette && palette.bg) || "#0b0b12";
+
+  ctx.save();
   ctx.clearRect(0, 0, width, height);
   // ND-safe: fill background first to avoid flashes
-  ctx.fillStyle = palette.bg;
+  ctx.fillStyle = background;
   ctx.fillRect(0, 0, width, height);
+  ctx.lineJoin = "round";
+  ctx.lineCap = "round";
 
   // Layer order preserves depth: base geometry first, lattice last
-  drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTreeOfLife(ctx, width, height, palette.layers[1], NUM);
-  drawFibonacciCurve(ctx, width, height, palette.layers[2], NUM);
-  drawHelixLattice(ctx, width, height, palette.layers[3], NUM);
+  drawVesica(ctx, width, height, layerColors[0], NUM);
+  drawTreeOfLife(ctx, width, height, layerColors[1], NUM);
+  drawFibonacciCurve(ctx, width, height, layerColors[2], NUM);
+  drawHelixLattice(ctx, width, height, layerColors[3], NUM);
+  ctx.restore();
+}
+
+function normalizeLayers(palette) {
+  const tones = palette && Array.isArray(palette.layers) ? [...palette.layers] : [];
+  const filler = (palette && palette.ink) || "#e8e8f0";
+  while (tones.length < 4) {
+    tones.push(filler);
+  }
+  return tones;
 }
 
 // Layer 1: Vesica field using a 3x3 grid
@@ -56,6 +72,7 @@ function drawVesica(ctx, w, h, color, NUM) {
  * Nodes are spaced using verticalStep = h / NUM.TWENTYTWO. Edges are taken from a fixed raw path list and sliced to NUM.TWENTYTWO entries;
  * each path is stroked with the provided color. Node circles are filled and sized relative to the canvas using NUM.TWENTYTWO, NUM.NINE, and NUM.THREE.
  *
+ * @param {CanvasRenderingContext2D} ctx - Target 2D drawing context.
  * @param {number} w - Canvas width in pixels.
  * @param {number} h - Canvas height in pixels.
  * @param {string} color - Stroke and fill color for lines and nodes.
@@ -118,7 +135,11 @@ function drawFibonacciCurve(ctx, w, h, color, NUM) {
     const r = scale * Math.pow(phi, i / NUM.NINE);
     const x = center.x + r * Math.cos(theta);
     const y = center.y + r * Math.sin(theta);
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
   }
   ctx.stroke();
 }
@@ -130,6 +151,7 @@ function drawFibonacciCurve(ctx, w, h, color, NUM) {
  * vertical bars to form a lattice. Geometry is parameterized so the pattern scales with
  * the canvas and the provided numeric configuration.
  *
+ * @param {CanvasRenderingContext2D} ctx - Target 2D drawing context.
  * @param {number} w - Canvas width in pixels.
  * @param {number} h - Canvas height in pixels.
  * @param {string} color - Stroke color used for strands and crossbars.
@@ -149,7 +171,11 @@ function drawHelixLattice(ctx, w, h, color, NUM) {
   for (let i = 0; i <= steps; i++) {
     const x = (i / steps) * w;
     const y = mid + amp * Math.sin(i / NUM.ELEVEN);
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
   }
   ctx.stroke();
 
@@ -158,12 +184,16 @@ function drawHelixLattice(ctx, w, h, color, NUM) {
   for (let i = 0; i <= steps; i++) {
     const x = (i / steps) * w;
     const y = mid + amp * Math.sin(i / NUM.ELEVEN + Math.PI);
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
   }
   ctx.stroke();
 
   // crossbars every 16 steps (approx 144/9)
-  const barStep = Math.floor(steps / NUM.NINE); // ND-safe: static crossbars provide calm symmetry
+  const barStep = Math.max(1, Math.floor(steps / NUM.NINE)); // ND-safe: static crossbars provide calm symmetry
   for (let i = 0; i <= steps; i += barStep) {
     const x = (i / steps) * w;
     const y1 = mid + amp * Math.sin(i / NUM.ELEVEN);


### PR DESCRIPTION
## Summary
- replace the previous atlas shell with a dedicated Cosmic Helix canvas page that loads gently even when the palette JSON is missing
- harden the ES module renderer with palette normalization, round joins, and inline documentation of the numerology-driven geometry
- refresh the renderer README to highlight the offline workflow, layer order, and ND-safe guarantees

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd0570f4b08328ab8a35ee75d5823b