### PR TITLE
Remove Git LFS and inline Black Madonna asset

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,1 @@
-*.png  filter=lfs diff=lfs merge=lfs -text
-*.tif  filter=lfs diff=lfs merge=lfs -text
-*.tiff filter=lfs diff=lfs merge=lfs -text
-*.exr  filter=lfs diff=lfs merge=lfs -text
-*.hdr  filter=lfs diff=lfs merge=lfs -text
-*.webp filter=lfs diff=lfs merge=lfs -text
-*.psd  filter=lfs diff=lfs merge=lfs -text
+# Git LFS disabled for static assets; no binary filters active.

--- a/data/nodes.json
+++ b/data/nodes.json
@@ -5,7 +5,7 @@
     "type": "archetype",
     "numerology": 0,
     "lore": "Primordial Void; Holy Fool.",
-    "art": "img/black-madonna.webp",
+    "art": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO8N0a8AAAAASUVORK5CYII=",
     "lab": "labs/void-lab.html",
     "links": ["01-magician"],
     "tags": ["origin", "aurora-gate"],

--- a/img/black-madonna.png
+++ b/img/black-madonna.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a2d0244d591f88a4ca87d2d97e1eda82994638bf5639f4c7e12b3e3540522d5
-size 97

--- a/img/black-madonna.webp
+++ b/img/black-madonna.webp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1dd8f547520d017a36640fff64a75728bf7a5fef1c4fd9cd1fe3898628f10973
-size 6062

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   <main id="main" tabindex="-1">
     <section class="hero" aria-labelledby="hero-heading">
       <div class="hero-media">
-        <img src="img/black-madonna.webp" alt="Aurora gate gradient evoking Leonora Carrington constellations." loading="lazy" decoding="async" width="720" height="450">
+        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO8N0a8AAAAASUVORK5CYII=" alt="Aurora gate gradient evoking Leonora Carrington constellations." loading="lazy" decoding="async" width="720" height="450">
       </div>
       <div class="hero-copy">
         <h2 id="hero-heading">Aurora Gate Research Anchor</h2>

--- a/service-worker.js
+++ b/service-worker.js
@@ -6,7 +6,7 @@ const PRECACHE_URLS = [
   './manifest.webmanifest',
   './js/loadNodes.js',
   './data/nodes.json',
-  './img/black-madonna.webp',
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO8N0a8AAAAASUVORK5CYII=',
   './img/icons/icon-192.png',
   './img/icons/icon-512.png',
   './labs/void-lab.html'

--- a/site/app/data/nodes.json
+++ b/site/app/data/nodes.json
@@ -5,7 +5,7 @@
     "type": "archetype",
     "numerology": 0,
     "lore": "Primordial Void; Holy Fool.",
-    "art": "img/black-madonna.webp",
+    "art": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO8N0a8AAAAASUVORK5CYII=",
     "lab": "labs/void-lab.html",
     "links": ["01-magician"],
     "tags": ["origin", "aurora-gate"],

--- a/site/app/index.html
+++ b/site/app/index.html
@@ -27,7 +27,7 @@
   <main id="main" tabindex="-1">
     <section class="hero" aria-labelledby="hero-heading">
       <div class="hero-media">
-        <img src="img/black-madonna.webp" alt="Aurora gate gradient evoking Leonora Carrington constellations." loading="lazy" decoding="async" width="720" height="450">
+        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO8N0a8AAAAASUVORK5CYII=" alt="Aurora gate gradient evoking Leonora Carrington constellations." loading="lazy" decoding="async" width="720" height="450">
       </div>
       <div class="hero-copy">
         <h2 id="hero-heading">Aurora Gate Research Anchor</h2>

--- a/site/app/service-worker.js
+++ b/site/app/service-worker.js
@@ -6,7 +6,7 @@ const PRECACHE_URLS = [
   './manifest.webmanifest',
   './js/loadNodes.js',
   './data/nodes.json',
-  './img/black-madonna.webp',
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO8N0a8AAAAASUVORK5CYII=',
   './img/icons/icon-192.png',
   './img/icons/icon-512.png',
   './labs/void-lab.html'


### PR DESCRIPTION
## Summary
- disable Git LFS filters so image assets no longer require LFS
- delete the broken Black Madonna pointers and inline the fallback art as a data URL across the app
- update precache data and node metadata to use the embedded PNG placeholder instead of external files

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdda49aed4832896ec9d2693fac5af

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Replaced the hero image with a lightweight embedded placeholder, reducing external asset loads and altering the visual to a minimal graphic.
- Chores
  - Disabled large file storage for static images.
  - Migrated image references from external files to embedded assets.
  - Updated offline caching to reflect embedded assets.
  - Removed an obsolete image from the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->