### PR TITLE
Add offline cosmic helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,0 +1,33 @@
+# Cosmic Helix Renderer
+
+Offline-first sacred geometry renderer designed for ND-safe viewing. No build
+step, no workflows, no runtime dependencies: double-click `index.html` to open
+the 1440×900 canvas.
+
+## Files
+- `index.html` – Entry point with safe status messaging and canvas bootstrap.
+- `js/helix-renderer.mjs` – Pure ES module that draws the four ordered layers.
+- `data/palette.json` – Preferred palette; the renderer falls back if missing.
+
+## Layer order
+1. **Vesica field** – Interlocking circles arranged on a 7×9 grid using
+   constants 7, 9, 11, and 33 to shape the overlaps. Lines are translucent so
+   they stay meditative.
+2. **Tree of Life** – Ten sephirot and twenty-two paths, scaled with constants
+   3, 7, 9, 11, 22, and 33 for respectful spacing.
+3. **Fibonacci curve** – Static logarithmic spiral with markers every 11 steps
+   to honour the sequence pacing. The curve grows from radius ratios anchored by
+   22, 33, and 144.
+4. **Double helix lattice** – Two calm strands sampled across 99 points with 22
+   static rungs. The helix never animates; anchor discs show roots instead.
+
+## ND-safe choices
+- No animation, autoplay, or flashing changes.
+- Calming palette with sufficient contrast, declared in CSS and JSON.
+- Pure geometric primitives; no raster textures or overlays.
+- Canvas is deterministic; same input always yields the same figure.
+
+## Offline usage
+Open `index.html` directly in a browser. If the palette JSON cannot be read
+(browsers sometimes block file:// fetch), the renderer posts a status note and
+switches to the built-in safe palette.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
+  </header>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || defaults.palette;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+  </script>
+</body>
+</html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,0 +1,293 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers:
+    1) Vesica field (intersecting circles)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
+    3) Fibonacci curve (log spiral polyline; static)
+    4) Double-helix lattice (two phase-shifted strands with rungs)
+
+  We keep functions pure and small, and describe ND-safe rationale inline so
+  collaborators understand why the geometry stays static and high-contrast.
+*/
+
+const DEFAULT_NUM = {
+  THREE: 3,
+  SEVEN: 7,
+  NINE: 9,
+  ELEVEN: 11,
+  TWENTYTWO: 22,
+  THIRTYTHREE: 33,
+  NINETYNINE: 99,
+  ONEFORTYFOUR: 144
+};
+
+const DEFAULT_PALETTE = {
+  bg: "#0b0b12",
+  ink: "#e8e8f0",
+  layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+};
+
+export function renderHelix(ctx, options = {}) {
+  if (!ctx) {
+    return;
+  }
+
+  const width = options.width ?? ctx.canvas?.width ?? 0;
+  const height = options.height ?? ctx.canvas?.height ?? 0;
+  const NUM = { ...DEFAULT_NUM, ...(options.NUM || {}) };
+  const palette = normalisePalette(options.palette);
+
+  ctx.save();
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.clearRect(0, 0, width, height);
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+
+  fillBackground(ctx, width, height, palette);
+
+  const dims = { width, height };
+  drawVesicaField(ctx, dims, palette, NUM);
+  drawTreeOfLife(ctx, dims, palette, NUM);
+  drawFibonacciCurve(ctx, dims, palette, NUM);
+  drawDoubleHelix(ctx, dims, palette, NUM);
+
+  ctx.restore();
+}
+
+function normalisePalette(custom) {
+  const palette = { ...DEFAULT_PALETTE, ...(custom || {}) };
+  const baseLayers = DEFAULT_PALETTE.layers;
+  const provided = Array.isArray(palette.layers) ? palette.layers : baseLayers;
+  palette.layers = baseLayers.map((color, index) => provided[index] ?? color);
+  return palette;
+}
+
+function fillBackground(ctx, width, height, palette) {
+  ctx.save();
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0, 0, width, height);
+  ctx.restore();
+}
+
+function drawVesicaField(ctx, dims, palette, NUM) {
+  const { width, height } = dims;
+  const rows = NUM.NINE; // 9 rows encode triple triads.
+  const cols = NUM.SEVEN; // 7 columns mirror the planets.
+  const radius = Math.min(width, height) / NUM.ELEVEN;
+  const horizontalStep = radius * (NUM.NINE / NUM.ELEVEN);
+  const verticalStep = radius * (Math.sqrt(3) / 2);
+  const startX = width / 2 - (cols - 1) * horizontalStep / 2;
+  const startY = height / 2 - (rows - 1) * verticalStep / 2;
+
+  ctx.save();
+  ctx.strokeStyle = palette.layers[0];
+  ctx.globalAlpha = 0.32; // Soft lines for a meditative field.
+  ctx.lineWidth = 1.5;
+
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const cx = startX + col * horizontalStep;
+      const cy = startY + row * verticalStep;
+      ctx.beginPath();
+      ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+
+  // Central vesica pair with 33:22 ratio to emphasise the heart of the lattice.
+  const centralRadius = radius * (NUM.THIRTYTHREE / NUM.TWENTYTWO);
+  ctx.globalAlpha = 0.45;
+  ctx.lineWidth = 2;
+  const offset = centralRadius / NUM.THREE;
+  ctx.beginPath();
+  ctx.arc(width / 2 - offset, height / 2, centralRadius, 0, Math.PI * 2);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.arc(width / 2 + offset, height / 2, centralRadius, 0, Math.PI * 2);
+  ctx.stroke();
+
+  ctx.restore();
+}
+
+function drawTreeOfLife(ctx, dims, palette, NUM) {
+  const { width, height } = dims;
+  const centerX = width / 2;
+  const xSpacing = width / NUM.SEVEN;
+  const ySpacing = height / NUM.NINE;
+  const topMargin = height / NUM.ELEVEN;
+  const nodeRadius = Math.min(width, height) / NUM.THIRTYTHREE;
+
+  const nodes = [
+    { id: "keter", x: centerX, y: topMargin },
+    { id: "chokmah", x: centerX - xSpacing * 0.75, y: topMargin + ySpacing },
+    { id: "binah", x: centerX + xSpacing * 0.75, y: topMargin + ySpacing },
+    { id: "chesed", x: centerX - xSpacing, y: topMargin + ySpacing * 2 },
+    { id: "geburah", x: centerX + xSpacing, y: topMargin + ySpacing * 2 },
+    { id: "tiphareth", x: centerX, y: topMargin + ySpacing * 3.3 },
+    { id: "netzach", x: centerX - xSpacing * 1.05, y: topMargin + ySpacing * 4.6 },
+    { id: "hod", x: centerX + xSpacing * 1.05, y: topMargin + ySpacing * 4.6 },
+    { id: "yesod", x: centerX, y: topMargin + ySpacing * 6 },
+    { id: "malkuth", x: centerX, y: topMargin + ySpacing * 7.1 }
+  ];
+
+  const paths = [
+    [0, 1], [0, 2], [0, 5],
+    [1, 2], [1, 3], [1, 5], [1, 6],
+    [2, 4], [2, 5], [2, 7],
+    [3, 4], [3, 5], [3, 6],
+    [4, 5], [4, 7],
+    [5, 6], [5, 7], [5, 8],
+    [6, 7], [6, 8], [7, 8],
+    [8, 9]
+  ];
+
+  ctx.save();
+  ctx.strokeStyle = palette.layers[1];
+  ctx.globalAlpha = 0.7;
+  ctx.lineWidth = 2.2;
+
+  for (const [a, b] of paths) {
+    const start = nodes[a];
+    const end = nodes[b];
+    ctx.beginPath();
+    ctx.moveTo(start.x, start.y);
+    ctx.lineTo(end.x, end.y);
+    ctx.stroke();
+  }
+
+  ctx.fillStyle = palette.layers[2];
+  ctx.globalAlpha = 0.95;
+  for (const node of nodes) {
+    ctx.beginPath();
+    ctx.arc(node.x, node.y, nodeRadius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = palette.ink;
+    ctx.globalAlpha = 0.6;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(node.x, node.y, nodeRadius * 0.6, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.globalAlpha = 0.95;
+    ctx.strokeStyle = palette.layers[2];
+  }
+
+  ctx.restore();
+}
+
+function drawFibonacciCurve(ctx, dims, palette, NUM) {
+  const { width, height } = dims;
+  const centre = { x: width * 0.27, y: height * 0.62 };
+  const startRadius = Math.min(width, height) / NUM.TWENTYTWO;
+  const finalRadius = Math.min(width, height) / NUM.THREE;
+  const steps = NUM.NINETYNINE;
+  const totalAngle = NUM.THREE * Math.PI; // 1.5 rotations keeps the curve calm.
+
+  const points = [];
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps;
+    const angle = t * totalAngle;
+    const radius = startRadius * Math.pow(finalRadius / startRadius, t);
+    const x = centre.x + Math.cos(angle) * radius;
+    const y = centre.y + Math.sin(angle) * radius;
+    points.push({ x, y });
+  }
+
+  ctx.save();
+  ctx.strokeStyle = palette.layers[3];
+  ctx.lineWidth = 3;
+  ctx.globalAlpha = 0.85;
+  strokePolyline(ctx, points);
+
+  // Quiet markers on every 11th point to honour the sequence pacing.
+  ctx.fillStyle = palette.layers[4];
+  ctx.globalAlpha = 0.55;
+  const markerRadius = Math.min(width, height) / NUM.ONEFORTYFOUR;
+  for (let i = 0; i < points.length; i += NUM.ELEVEN) {
+    const p = points[i];
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, markerRadius, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  ctx.restore();
+}
+
+function drawDoubleHelix(ctx, dims, palette, NUM) {
+  const { width, height } = dims;
+  const helixHeight = height * 0.72;
+  const top = (height - helixHeight) / 2;
+  const amplitude = width / NUM.ELEVEN;
+  const steps = NUM.NINETYNINE;
+  const phaseShift = Math.PI / NUM.SEVEN;
+  const leftOffset = width * 0.35;
+  const rightOffset = width * 0.65;
+  const totalAngle = NUM.NINE * Math.PI / NUM.THREE; // 3π for gentle twist.
+
+  const leftPoints = [];
+  const rightPoints = [];
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps;
+    const y = top + helixHeight * t;
+    const angle = totalAngle * t;
+    const leftX = leftOffset + Math.sin(angle) * amplitude;
+    const rightX = rightOffset + Math.sin(angle + phaseShift) * amplitude;
+    leftPoints.push({ x: leftX, y });
+    rightPoints.push({ x: rightX, y });
+  }
+
+  ctx.save();
+  ctx.globalAlpha = 0.85;
+  ctx.lineWidth = 2.4;
+  ctx.strokeStyle = palette.layers[4];
+  strokePolyline(ctx, leftPoints);
+  ctx.strokeStyle = palette.layers[5];
+  strokePolyline(ctx, rightPoints);
+
+  // Lattice rungs every fourth step (22 connectors over 99 samples).
+  const rungStep = Math.max(1, Math.floor(steps / NUM.TWENTYTWO));
+  ctx.strokeStyle = palette.ink;
+  ctx.globalAlpha = 0.35;
+  ctx.lineWidth = 1.5;
+  for (let i = 0; i <= steps; i += rungStep) {
+    const left = leftPoints[i];
+    const right = rightPoints[i];
+    ctx.beginPath();
+    ctx.moveTo(left.x, left.y);
+    ctx.lineTo(right.x, right.y);
+    ctx.stroke();
+  }
+
+  // Anchor circles to show the helix roots without implying motion.
+  const anchorRadius = Math.min(width, height) / NUM.TWENTYTWO;
+  ctx.fillStyle = palette.layers[5];
+  ctx.globalAlpha = 0.25;
+  ctx.beginPath();
+  ctx.arc(leftPoints[0].x, top, anchorRadius, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.beginPath();
+  ctx.arc(rightPoints[0].x, top, anchorRadius, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.beginPath();
+  ctx.arc(leftPoints[steps].x, top + helixHeight, anchorRadius, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.beginPath();
+  ctx.arc(rightPoints[steps].x, top + helixHeight, anchorRadius, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.restore();
+}
+
+function strokePolyline(ctx, points) {
+  if (points.length === 0) {
+    return;
+  }
+  ctx.beginPath();
+  ctx.moveTo(points[0].x, points[0].y);
+  for (let i = 1; i < points.length; i++) {
+    const p = points[i];
+    ctx.lineTo(p.x, p.y);
+  }
+  ctx.stroke();
+}


### PR DESCRIPTION
## Summary
- add an offline-first index page with ND-safe styling and palette fallback messaging
- implement a modular canvas renderer that draws the vesica grid, tree of life, fibonacci curve, and static double helix using numerology constants
- document the renderer layers and offline usage guidance

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d032db1efc8328824ce4fc12ed928c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an offline, ND-safe static renderer that visualizes layered sacred geometry on a canvas.
  - Supports loading a color palette from a JSON source with a safe default fallback.
  - Works without a build step; open the page directly to render.
  - Includes high-contrast, no-motion presentation and clear status messaging for palette loading.

- Documentation
  - Added a comprehensive guide covering usage, layers, palette behavior, offline operation, and ND-safe design choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->