### PR TITLE
Add offline cosmic helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,0 +1,36 @@
+# Cosmic Helix Renderer
+
+This static, ND-safe renderer draws the layered cosmology described in the Cosmic Helix brief. Open `index.html` directly in any modern browser (no server or build tools required) to see the 1440×900 canvas render the following layers:
+
+1. **Vesica field** — intersecting circles forming the foundational harmonic grid.
+2. **Tree-of-Life scaffold** — ten sephirot and twenty-two connecting paths.
+3. **Fibonacci curve** — a calm golden spiral polyline guiding motion-free growth.
+4. **Double-helix lattice** — two static strands with gentle crossbars, reinforcing depth without animation.
+
+## Offline-first behavior
+
+- All files are local. Double-click `index.html` and the module will run without any network access.
+- The renderer attempts to load `data/palette.json`. If the file is missing or malformed, the canvas displays a small inline notice and falls back to a bundled ND-safe palette.
+- Geometry routines are parameterized with numerology constants (3, 7, 9, 11, 22, 33, 99, 144) to align with the layered cosmology requirements.
+
+## Customizing the palette
+
+Edit `data/palette.json` to adjust background, ink, or layer colors. The structure is:
+
+```json
+{
+  "bg": "#0a1419",
+  "ink": "#f2f7f7",
+  "layers": ["#4ab6b6", "#7bd389", "#f2d184", "#d1b3ff", "#f8c0c8", "#9fd0ff"]
+}
+```
+
+Keep the hues calm and high-contrast for ND-safe readability. If `layers` contains fewer than six colors the renderer will reuse them cyclically, ensuring harmonious coverage.
+
+## File overview
+
+- `index.html` — shell document with inline status text and module bootstrap.
+- `js/helix-renderer.mjs` — pure ES module that draws each layer in order.
+- `data/palette.json` — local palette definition consumed by the renderer.
+
+No build steps or workflows are required. The renderer operates entirely offline and does not rely on external libraries.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
+  </header>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || defaults.palette;
+    const fallbackNotice = palette ? "" : "Palette file missing; safe fallback engaged.";
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, fallbackNotice });
+  </script>
+</body>
+</html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,0 +1,282 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers:
+    1) Vesica field (intersecting circles)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
+    3) Fibonacci curve (golden spiral polyline; static)
+    4) Double-helix lattice (two phase-shifted strands)
+
+  Why: respects Cosmic Helix brief with calm palette, no motion, and offline-only dependencies.
+*/
+
+const FALLBACK_PALETTE = {
+  bg: "#0b0b12",
+  ink: "#e8e8f0",
+  layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+};
+
+export function renderHelix(ctx, options) {
+  const { width, height, NUM, fallbackNotice } = options;
+  const palette = normalizePalette(options.palette);
+
+  ctx.save();
+  clearCanvas(ctx, width, height, palette.bg);
+
+  drawVesicaField(ctx, { width, height }, palette, NUM);
+  drawTreeOfLife(ctx, { width, height }, palette, NUM);
+  drawFibonacciCurve(ctx, { width, height }, palette, NUM);
+  drawHelixLattice(ctx, { width, height }, palette, NUM);
+
+  if (fallbackNotice) {
+    drawFallbackNotice(ctx, { width, height }, palette, fallbackNotice);
+  }
+  ctx.restore();
+}
+
+function normalizePalette(raw) {
+  /* Why: guarantees ND-safe fallback even when palette data is missing or partial. */
+  const candidate = raw || FALLBACK_PALETTE;
+  const layers = Array.isArray(candidate.layers) && candidate.layers.length > 0
+    ? candidate.layers
+    : FALLBACK_PALETTE.layers;
+  return {
+    bg: candidate.bg || FALLBACK_PALETTE.bg,
+    ink: candidate.ink || FALLBACK_PALETTE.ink,
+    layers
+  };
+}
+
+function pickLayerColor(palette, index) {
+  /* Why: loops palette gracefully to keep harmonious layering. */
+  return palette.layers[index % palette.layers.length];
+}
+
+function clearCanvas(ctx, width, height, color) {
+  /* Why: establishes calm background before layering sacred geometry. */
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, width, height);
+}
+
+function drawVesicaField(ctx, dims, palette, NUM) {
+  /* Why: Vesica Piscis grid builds foundational harmony for the remaining layers. */
+  const { width, height } = dims;
+  const columnCount = NUM.ELEVEN;
+  const rowCount = NUM.SEVEN; // seven vesica bands reinforce layered harmony
+  const spacingX = width / (columnCount - 1);
+  const spacingY = height / (rowCount + 2);
+  const radius = Math.min(spacingX, spacingY) * (NUM.ELEVEN / NUM.TWENTYTWO);
+  const color = pickLayerColor(palette, 0);
+
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.lineWidth = radius / NUM.ELEVEN;
+  ctx.globalAlpha = 0.28;
+
+  for (let row = 0; row < rowCount; row += 1) {
+    const offset = (row % 2 === 0) ? 0 : spacingX / 2;
+    const cy = spacingY * (row + 1.5);
+    for (let col = 0; col < columnCount; col += 1) {
+      const cx = col * spacingX + offset;
+      if (cx < -radius || cx > width + radius) {
+        continue;
+      }
+      ctx.beginPath();
+      ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+  ctx.restore();
+}
+
+function drawTreeOfLife(ctx, dims, palette, NUM) {
+  /* Why: Tree-of-Life anchors narrative structure with balanced vertical rhythm. */
+  const { width, height } = dims;
+  const marginTop = height / NUM.NINE;
+  const columnOffset = width / NUM.THREE;
+  const centerX = width / 2;
+
+  const nodes = [
+    { x: centerX, y: marginTop * 0.5 },
+    { x: centerX + columnOffset / 2, y: marginTop * 1.6 },
+    { x: centerX - columnOffset / 2, y: marginTop * 1.6 },
+    { x: centerX + columnOffset / 2, y: marginTop * 3 },
+    { x: centerX - columnOffset / 2, y: marginTop * 3 },
+    { x: centerX, y: marginTop * 4.2 },
+    { x: centerX + columnOffset / 2, y: marginTop * 5.6 },
+    { x: centerX - columnOffset / 2, y: marginTop * 5.6 },
+    { x: centerX, y: marginTop * 7 },
+    { x: centerX, y: marginTop * 8.4 }
+  ];
+
+  const paths = [
+    [0, 1], [0, 2], [1, 2],
+    [1, 3], [2, 4], [3, 4],
+    [3, 5], [4, 5], [3, 6],
+    [4, 7], [5, 6], [5, 7],
+    [6, 7], [6, 8], [7, 8],
+    [5, 8], [8, 9], [0, 5],
+    [1, 5], [2, 5], [3, 8],
+    [4, 8]
+  ];
+
+  if (paths.length !== NUM.TWENTYTWO) {
+    throw new Error("Tree-of-Life path count must match 22 letters");
+  }
+
+  const pathColor = pickLayerColor(palette, 1);
+  const nodeColor = pickLayerColor(palette, 2);
+
+  ctx.save();
+  ctx.strokeStyle = pathColor;
+  ctx.lineWidth = width / NUM.ONEFORTYFOUR;
+  ctx.globalAlpha = 0.6;
+  ctx.beginPath();
+  for (const [fromIndex, toIndex] of paths) {
+    const from = nodes[fromIndex];
+    const to = nodes[toIndex];
+    ctx.moveTo(from.x, from.y);
+    ctx.lineTo(to.x, to.y);
+  }
+  ctx.stroke();
+
+  ctx.globalAlpha = 1;
+  ctx.fillStyle = nodeColor;
+  ctx.strokeStyle = palette.ink;
+  ctx.lineWidth = width / NUM.NINETYNINE;
+  const radius = width / NUM.ONEFORTYFOUR * NUM.THREE / NUM.ELEVEN;
+  for (const node of nodes) {
+    ctx.beginPath();
+    ctx.arc(node.x, node.y, radius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function drawFibonacciCurve(ctx, dims, palette, NUM) {
+  /* Why: Fibonacci spiral guides growth without animation, respecting ND-safe calm focus. */
+  const { width, height } = dims;
+  const goldenRatio = (1 + Math.sqrt(5)) / 2;
+  const fibCount = NUM.NINE;
+  const fib = fibonacciSequence(fibCount);
+  const baseScale = Math.min(width, height) / NUM.ONEFORTYFOUR * NUM.THIRTYTHREE / fib[fib.length - 1];
+  const center = {
+    x: width / NUM.THREE,
+    y: height - height / NUM.NINE
+  };
+  const steps = NUM.TWENTYTWO;
+  const startTheta = Math.PI / NUM.THREE;
+  const endTheta = startTheta + Math.PI * NUM.THREE;
+  const growth = Math.log(goldenRatio) / (Math.PI / 2);
+  const color = pickLayerColor(palette, 3);
+
+  const points = [];
+  for (let step = 0; step <= steps; step += 1) {
+    const t = step / steps;
+    const theta = startTheta + (endTheta - startTheta) * t;
+    const radius = baseScale * Math.exp(growth * theta);
+    const x = center.x + Math.cos(theta) * radius;
+    const y = center.y + Math.sin(theta) * radius;
+    points.push({ x, y });
+  }
+
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.lineWidth = width / NUM.NINETYNINE;
+  ctx.globalAlpha = 0.9;
+  ctx.beginPath();
+  for (let i = 0; i < points.length; i += 1) {
+    const point = points[i];
+    if (i === 0) {
+      ctx.moveTo(point.x, point.y);
+    } else {
+      ctx.lineTo(point.x, point.y);
+    }
+  }
+  ctx.stroke();
+  ctx.restore();
+}
+
+function fibonacciSequence(count) {
+  const seq = [1, 1];
+  while (seq.length < count) {
+    const next = seq[seq.length - 1] + seq[seq.length - 2];
+    seq.push(next);
+  }
+  return seq;
+}
+
+function drawHelixLattice(ctx, dims, palette, NUM) {
+  /* Why: double helix gives layered depth using two static strands and gentle crossbars. */
+  const { width, height } = dims;
+  const margin = height / NUM.NINE;
+  const strandHeight = height - margin * 2;
+  const amplitude = width / NUM.SEVEN;
+  const segments = NUM.TWENTYTWO;
+  const strandColorA = pickLayerColor(palette, 4);
+  const strandColorB = pickLayerColor(palette, 5);
+
+  const leftPoints = [];
+  const rightPoints = [];
+  for (let i = 0; i <= segments; i += 1) {
+    const t = i / segments;
+    const theta = Math.PI * NUM.THREE * t;
+    const y = margin + strandHeight * (1 - t);
+    const phase = Math.sin(theta);
+    const xLeft = width / 2 - amplitude / 2 + phase * amplitude / NUM.THREE;
+    const xRight = width / 2 + amplitude / 2 + Math.sin(theta + Math.PI) * amplitude / NUM.THREE;
+    leftPoints.push({ x: xLeft, y });
+    rightPoints.push({ x: xRight, y });
+  }
+
+  ctx.save();
+  ctx.lineWidth = width / NUM.ONEFORTYFOUR;
+  ctx.globalAlpha = 0.8;
+  ctx.strokeStyle = strandColorA;
+  strokePolyline(ctx, leftPoints);
+  ctx.strokeStyle = strandColorB;
+  strokePolyline(ctx, rightPoints);
+
+  ctx.globalAlpha = 0.4;
+  ctx.strokeStyle = palette.ink;
+  const crossbarInterval = Math.max(1, Math.round(segments / NUM.ELEVEN));
+  for (let i = 0; i <= segments; i += crossbarInterval) {
+    const left = leftPoints[i];
+    const right = rightPoints[i];
+    if (!left || !right) {
+      continue;
+    }
+    ctx.beginPath();
+    ctx.moveTo(left.x, left.y);
+    ctx.lineTo(right.x, right.y);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function strokePolyline(ctx, points) {
+  ctx.beginPath();
+  for (let i = 0; i < points.length; i += 1) {
+    const point = points[i];
+    if (i === 0) {
+      ctx.moveTo(point.x, point.y);
+    } else {
+      ctx.lineTo(point.x, point.y);
+    }
+  }
+  ctx.stroke();
+}
+
+function drawFallbackNotice(ctx, dims, palette, message) {
+  /* Why: inline notice affirms safe fallback without relying on DOM overlays. */
+  const { width } = dims;
+  ctx.save();
+  ctx.globalAlpha = 0.72;
+  ctx.fillStyle = palette.ink;
+  ctx.font = "14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif";
+  ctx.textAlign = "right";
+  ctx.fillText(message, width - 24, 32);
+  ctx.restore();
+}


### PR DESCRIPTION
## Summary
- add an offline `index.html` shell that loads the canvas renderer with palette fallback messaging
- implement `js/helix-renderer.mjs` to draw vesica field, Tree-of-Life scaffold, Fibonacci spiral, and a static double helix
- document offline usage and palette customization details in `README_RENDERER.md`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a42abff88328bf0270be2fcc25a9