### PR TITLE
Add static cosmic helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,11 +1,9 @@
-Per Texturas Numerorum, Spira Loquitur.
-
 # Cosmic Helix Renderer
 
-Static, ND-safe HTML5 canvas renderer for layered sacred geometry. Open [index.html](./index.html) directly in any modern browser; no build tools, servers, or workflows are required.
+Static, ND-safe HTML5 canvas renderer for layered sacred geometry. Open [`index.html`](./index.html) directly in any modern browser; no build tools, servers, or workflows are required.
 
 ## Layer Order (depth preserved)
-1. **Vesica field** — intersecting circles on a triadic grid.
+1. **Vesica field** — intersecting circles on a triadic-by-heptadic grid to seed the field.
 2. **Tree-of-Life scaffold** — ten sephirot with twenty-two connecting paths.
 3. **Fibonacci curve** — fixed logarithmic spiral honoring natural growth.
 4. **Double-helix lattice** — two phase-shifted strands bound by calm crossbars.
@@ -15,11 +13,7 @@ Each layer draws with the next tone from [`data/palette.json`](./data/palette.js
 ## Numerology as Geometry Grammar
 The routines respect the requested constants: **3**, **7**, **9**, **11**, **22**, **33**, **99**, and **144**. They govern grid counts, spacing, and sample steps so the output stays faithful to the Cathedral canon while remaining static.
 
-## Local Use (offline)
-1. Double-click [index.html](./index.html).
-2. The 1440×900 canvas renders immediately, pulling data only from local files.
-3. Optional: adjust hues in [`data/palette.json`](./data/palette.json) while keeping six calm tones (`bg`, `ink`, and four-or-more `layers`).
-
+Highlights:
 - **21 pillars** – a Fibonacci node (8 + 13) aligning to Tarot majors and 21 Taras.
 - **33 spine** – triple elevens forming the Christic ladder.
 - **72 Shem angels/demons** – lunar decan cycle (8 × 9).
@@ -28,23 +22,16 @@ The routines respect the requested constants: **3**, **7**, **9**, **11**, **22*
 - **144 lattice** – perfect square of 12 and 8th Fibonacci.
 - **243 completion** – fivefold power of the triad (3⁵).
 
-Geometry routines in this renderer reference sacred numbers 3, 7, 9, 11, 22, 33, 99, and 144 to keep proportions meaningful while staying static.
+Geometry routines in this renderer reference sacred numbers to keep proportions meaningful while staying static and offline.
 
-## Local Use
-Double-click [index.html](./index.html) in any modern browser. The 1440×900 canvas renders immediately with no network calls.
-The renderer depends on [`js/helix-renderer.mjs`](./js/helix-renderer.mjs) and optional [`data/palette.json`](./data/palette.json).
-Everything runs offline. The Pantheon atlas at the top of the page remains intact; the helix canvas sits beneath the node catalogue and shares the Calm Mode toggle for consistent softening.
+## Local Use (offline)
+1. Double-click [`index.html`](./index.html).
+2. The 1440×900 canvas renders immediately, pulling data only from local files.
+3. Optional: adjust hues in [`data/palette.json`](./data/palette.json) while keeping six calm tones (`bg`, `ink`, and at least four `layers`).
 
 ## ND-safe Notes
 - No motion or flashing; all elements render statically in layer order.
-- Palette uses gentle contrast for readability, with Calm Mode softening hues when toggled or when the OS requests reduced motion. Status text clarifies when fallbacks are engaged.
-- Skip link, `<main>` landmark, and status messaging keep the page navigable by keyboard and assistive tech.
-- Pure functions, ES modules, UTF-8, and LF newlines.
-- Palette file can be edited offline to adjust hues; the page falls back to built-in colors if it's missing and surfaces a small inline notice.
-
-
-## ND-safe Guarantees
-- No animation, autoplay, flashes, or motion scripting—`renderHelix` runs once per load.
-- Gentle contrast palette with clear outlines; fallback stays within the same tonal family.
-- Inline comments document why layer order, numerology, and calm defaults are preserved.
-- Pure ES modules, ASCII quotes, UTF-8, LF newlines, and small focused functions.
+- Palette uses gentle contrast for readability; fallback stays within the same tonal family.
+- Status text clarifies when fallbacks are engaged.
+- Pure functions, ES modules, ASCII quotes, UTF-8, and LF newlines.
+- Palette file can be edited offline to adjust hues; the page falls back to built-in colors if it is missing and surfaces a small inline notice.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
+  </header>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || defaults.palette;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+  </script>
+</body>
+</html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,0 +1,278 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers:
+    1) Vesica field (intersecting circles)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
+    3) Fibonacci curve (log spiral polyline; static)
+    4) Double-helix lattice (two phase-shifted strands tied by calm crossbars)
+
+  The drawing routines keep to small pure helpers for clarity and to respect
+  the ND-safe directive: no motion, gentle contrast, and predictable structure.
+*/
+
+export function renderHelix(ctx, options) {
+  if (!ctx || !options) {
+    return;
+  }
+
+  const config = normalizeOptions(options);
+  const { width, height, palette, NUM } = config;
+  const layers = palette.layers;
+
+  ctx.save();
+  drawBackground(ctx, palette.bg, width, height);
+
+  drawVesicaField(ctx, width, height, pickLayer(layers, 0), NUM);
+  drawTreeOfLife(ctx, width, height, palette.ink, pickLayer(layers, 1), NUM);
+  drawFibonacciCurve(ctx, width, height, pickLayer(layers, 2), NUM);
+  drawHelixLattice(ctx, width, height, pickLayer(layers, 3), pickLayer(layers, 4), NUM);
+
+  ctx.restore();
+}
+
+function normalizeOptions(options) {
+  const width = options.width || 1440;
+  const height = options.height || 900;
+  const palette = options.palette || { bg:"#0b0b12", ink:"#e8e8f0", layers:["#b1c7ff"] };
+  const NUM = options.NUM || { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+  return { width, height, palette, NUM };
+}
+
+function pickLayer(layers, index) {
+  if (!layers || layers.length === 0) {
+    return "#ffffff";
+  }
+  return layers[index % layers.length];
+}
+
+function drawBackground(ctx, color, width, height) {
+  ctx.save();
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, width, height);
+  ctx.restore();
+}
+
+/* Layer 1: Vesica field
+   Uses a triadic-by-heptadic grid (3 rows, 7 columns) with alternating offsets
+   so each circle intersects neighbors, evoking the Vesica Piscis without motion. */
+function drawVesicaField(ctx, width, height, color, NUM) {
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.lineWidth = Math.max(width, height) / NUM.NINETYNINE;
+  ctx.globalAlpha = 0.45;
+
+  const cols = NUM.SEVEN;
+  const rows = NUM.THREE;
+  const marginX = width / NUM.ELEVEN;
+  const marginY = height / NUM.NINE;
+  const usableWidth = width - marginX * 2;
+  const usableHeight = height - marginY * 2;
+  const stepX = usableWidth / (cols - 1);
+  const stepY = usableHeight / (rows - 1);
+  const radius = Math.min(stepX, stepY) * 0.75;
+
+  for (let row = 0; row < rows; row += 1) {
+    const offset = (row % 2 === 0) ? 0 : stepX / 2;
+    for (let col = 0; col < cols; col += 1) {
+      const cx = marginX + col * stepX + offset;
+      const cy = marginY + row * stepY;
+      drawCircle(ctx, cx, cy, radius);
+    }
+  }
+
+  ctx.restore();
+}
+
+/* Layer 2: Tree-of-Life scaffold
+   Ten nodes and twenty-two paths, scaled by numerology constants so the layout
+   matches the Cathedral canon while staying calm. */
+function drawTreeOfLife(ctx, width, height, nodeColor, lineColor, NUM) {
+  ctx.save();
+  const nodes = createTreeNodes(width, height, NUM);
+  const paths = createTreePaths();
+
+  ctx.strokeStyle = lineColor;
+  ctx.lineWidth = Math.max(width, height) / NUM.ONEFORTYFOUR;
+  ctx.globalAlpha = 0.55;
+
+  paths.forEach(([a, b]) => {
+    const start = nodes[a];
+    const end = nodes[b];
+    ctx.beginPath();
+    ctx.moveTo(start.x, start.y);
+    ctx.lineTo(end.x, end.y);
+    ctx.stroke();
+  });
+
+  ctx.fillStyle = nodeColor;
+  ctx.globalAlpha = 0.9;
+  const nodeRadius = Math.max(width, height) / NUM.NINETYNINE;
+  nodes.forEach((node) => {
+    ctx.beginPath();
+    ctx.arc(node.x, node.y, nodeRadius, 0, Math.PI * 2);
+    ctx.fill();
+  });
+
+  ctx.restore();
+}
+
+function createTreeNodes(width, height, NUM) {
+  const centerX = width / 2;
+  const verticalStep = height / (NUM.NINE + 2);
+  const horizontalSpread = width / NUM.THREE;
+  const sideOffset = horizontalSpread / NUM.SEVEN;
+
+  const levels = [
+    [{ x: centerX, y: verticalStep }],
+    [
+      { x: centerX - horizontalSpread / 2, y: verticalStep * 2.5 },
+      { x: centerX + horizontalSpread / 2, y: verticalStep * 2.5 }
+    ],
+    [
+      { x: centerX - horizontalSpread / 2 - sideOffset, y: verticalStep * 4 },
+      { x: centerX + horizontalSpread / 2 + sideOffset, y: verticalStep * 4 }
+    ],
+    [
+      { x: centerX - horizontalSpread / 2, y: verticalStep * 5.5 },
+      { x: centerX, y: verticalStep * 6.5 },
+      { x: centerX + horizontalSpread / 2, y: verticalStep * 5.5 }
+    ],
+    [
+      { x: centerX - horizontalSpread / 3, y: verticalStep * 8 },
+      { x: centerX + horizontalSpread / 3, y: verticalStep * 8 }
+    ],
+    [{ x: centerX, y: verticalStep * 9.5 }]
+  ];
+
+  return levels.flat();
+}
+
+function createTreePaths() {
+  return [
+    [0, 1], [0, 2], [1, 3], [2, 4], [3, 4],
+    [3, 5], [4, 5], [3, 6], [4, 7], [5, 6],
+    [5, 7], [5, 8], [6, 8], [7, 8], [8, 9],
+    [1, 2], [1, 5], [2, 5], [1, 6], [2, 7],
+    [0, 5], [6, 9]
+  ];
+}
+
+/* Layer 3: Fibonacci curve
+   Approximates a logarithmic spiral using 99 samples. Phi and numerology constants
+   control radius growth and step counts so the spiral feels organic yet calm. */
+function drawFibonacciCurve(ctx, width, height, color, NUM) {
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.lineWidth = Math.max(width, height) / NUM.ONEFORTYFOUR;
+  ctx.globalAlpha = 0.7;
+
+  const center = { x: width * 0.62, y: height * 0.58 };
+  const baseRadius = Math.min(width, height) / NUM.ELEVEN;
+  const points = createFibonacciPoints(center, baseRadius, NUM);
+
+  ctx.beginPath();
+  points.forEach((point, index) => {
+    if (index === 0) {
+      ctx.moveTo(point.x, point.y);
+    } else {
+      ctx.lineTo(point.x, point.y);
+    }
+  });
+  ctx.stroke();
+
+  ctx.restore();
+}
+
+function createFibonacciPoints(center, baseRadius, NUM) {
+  const phi = (1 + Math.sqrt(5)) / 2;
+  const turns = NUM.THREE;
+  const stepsPerTurn = NUM.ELEVEN;
+  const totalSteps = turns * stepsPerTurn * NUM.THREE;
+  const angleStep = (Math.PI * 2) / NUM.TWENTYTWO;
+  const radiusStep = 1 / NUM.THIRTYTHREE;
+
+  const points = [];
+  for (let i = 0; i <= totalSteps; i += 1) {
+    const angle = i * angleStep;
+    const radius = baseRadius * Math.pow(phi, i * radiusStep);
+    const x = center.x + Math.cos(angle) * radius;
+    const y = center.y + Math.sin(angle) * radius;
+    points.push({ x, y });
+  }
+  return points;
+}
+
+/* Layer 4: Double-helix lattice
+   Two sine-like strands phase-shifted by pi, sampled 144 times. Calm crossbars
+   every seventh sample hold the lattice together without motion. */
+function drawHelixLattice(ctx, width, height, primaryColor, secondaryColor, NUM) {
+  ctx.save();
+  const amplitude = width / NUM.THIRTYTHREE;
+  const verticalMargin = height / NUM.ELEVEN;
+  const usableHeight = height - verticalMargin * 2;
+  const steps = NUM.ONEFORTYFOUR;
+  const angleSpan = Math.PI * NUM.THREE;
+
+  const strandA = [];
+  const strandB = [];
+  for (let i = 0; i <= steps; i += 1) {
+    const t = i / steps;
+    const angle = angleSpan * t;
+    const y = verticalMargin + usableHeight * t;
+    const xA = width / 2 + Math.sin(angle) * amplitude;
+    const xB = width / 2 + Math.sin(angle + Math.PI) * amplitude;
+    strandA.push({ x: xA, y });
+    strandB.push({ x: xB, y });
+  }
+
+  drawStrand(ctx, strandA, primaryColor);
+  drawStrand(ctx, strandB, secondaryColor);
+  drawCrossbars(ctx, strandA, strandB, secondaryColor, NUM);
+
+  ctx.restore();
+}
+
+function drawStrand(ctx, points, color) {
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.globalAlpha = 0.75;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  points.forEach((point, index) => {
+    if (index === 0) {
+      ctx.moveTo(point.x, point.y);
+    } else {
+      ctx.lineTo(point.x, point.y);
+    }
+  });
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawCrossbars(ctx, strandA, strandB, color, NUM) {
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.globalAlpha = 0.35;
+  ctx.lineWidth = 1.5;
+
+  const step = NUM.SEVEN;
+  const limit = Math.min(strandA.length, strandB.length);
+  for (let i = 0; i < limit; i += step) {
+    const a = strandA[i];
+    const b = strandB[i];
+    ctx.beginPath();
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(b.x, b.y);
+    ctx.stroke();
+  }
+
+  ctx.restore();
+}
+
+function drawCircle(ctx, cx, cy, radius) {
+  ctx.beginPath();
+  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+  ctx.stroke();
+}


### PR DESCRIPTION
## Summary
- add standalone index.html that loads the helix renderer module and offline palette
- implement ND-safe layered canvas renderer with vesica field, tree of life, fibonacci spiral, and double helix lattice
- refresh README_RENDERER notes to describe usage, numerology, and fallbacks

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68d48f23dfc883288c7bbd9bd7e481ef