### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,4 +1,6 @@
 name: lighthouse
+permissions:
+  contents: read
 on:
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Bekalah/liber-arcanae/security/code-scanning/4](https://github.com/Bekalah/liber-arcanae/security/code-scanning/4)

To fix this problem, we should add a `permissions` block to the workflow. This can be done at the root level (which applies to all jobs in the workflow unless overridden), or within the `lhci` job if more granular control is necessary, but since there is only one job, it is simpler and clearer to add it at the root. The block should specify only the permissions required; in this case, the minimal and recommended permission for read-only usage is `contents: read`. To implement the change, insert a new `permissions:` block after the workflow `name:` line and before the `on:` block in `.github/workflows/lighthouse.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
