### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,4 +1,6 @@
 name: links
+permissions:
+  contents: read
 on:
   schedule:
     - cron: '0 3 * * *'


### PR DESCRIPTION
Potential fix for [https://github.com/Bekalah/liber-arcanae/security/code-scanning/7](https://github.com/Bekalah/liber-arcanae/security/code-scanning/7)

To fix this problem, you should specify the `permissions` field at either the workflow or the job level with the minimum privileges necessary for the workflow to function correctly. For the provided workflow, both actions—checking out code and running lychee link checking—only require read access to repository contents, not write permissions. Therefore, you should add a `permissions` block and set `contents: read`. This should be added at the workflow root (best), or under the check job; since only one job exists, the root is the simplest and most effective. Edit `.github/workflows/links.yml` by adding:

```
permissions:
  contents: read
```

immediately after the `name: links` line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
