### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/tools/dev-server.js
+++ b/tools/dev-server.js
@@ -10,6 +10,12 @@ const root = path.resolve(__dirname, '..'); // parent directory
 const server = http.createServer(async (req, res) => {
   const reqPath = path.normalize(decodeURI(req.url.split('?')[0]));
   let filePath = path.join(root, reqPath);
+  filePath = path.resolve(filePath);
+  if (!filePath.startsWith(root + path.sep)) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
   try {
     const info = await stat(filePath);
     if (info.isDirectory()) filePath = path.join(filePath, 'index.html');


### PR DESCRIPTION
Potential fix for [https://github.com/Bekalah/liber-arcanae/security/code-scanning/1](https://github.com/Bekalah/liber-arcanae/security/code-scanning/1)

To fix the problem, ensure that after constructing the full file path for a static asset, we check that the normalized (and real) path is still inside the intended document root directory. This can be accomplished by:
- Using `path.resolve` to canonicalize the joined path.
- (Optionally) Using `fs.realpath` if symbolic links are of concern, but most simply `path.resolve` works for ensuring traversal is blocked in most cases.
- Checking that the resolved `filePath` starts with the resolved intended root directory.
- If not, respond with HTTP 403 (Forbidden).

**Changes required:**
- After constructing `filePath`, make sure it is resolved and checked against `root` before accessing the file (stat/read).
- If this check fails, immediately respond with 403 and end the response.
- No new methods are needed; using `path.resolve` and `startsWith` suffices.
- No new packages are needed; all used modules are part of the Node.js standard library and are already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
