### PR TITLE
Potential fix for code scanning alert no. 8: Uncontrolled data used in path expression

### DIFF
--- a/tools/dev-server.mjs
+++ b/tools/dev-server.mjs
@@ -7,9 +7,12 @@
 
 import http from "http";
 import {promises as fs} from "fs";
-import {resolve, join} from "path";
+import {resolve, join, sep} from "path";
 
-const root = resolve(process.argv[2] || "..");
+let root = resolve(process.argv[2] || "..");
+if (!root.endsWith(sep)) {
+  root = root + sep;
+}
 const types = {
   ".html":"text/html",
   ".js":"text/javascript",
@@ -28,7 +31,7 @@ const server = http.createServer(async (req, res) => {
   try {
     const realPath = await fs.realpath(requestedPath);
     // Check that the resolved path is contained within root
-    if (!realPath.startsWith(root)) {
+    if (!(realPath === root.slice(0, -1) || realPath.startsWith(root))) {
       res.writeHead(403, {"Content-Type":"text/plain"});
       res.end("Forbidden");
       return;


### PR DESCRIPTION
Potential fix for [https://github.com/Bekalah/liber-arcanae/security/code-scanning/8](https://github.com/Bekalah/liber-arcanae/security/code-scanning/8)

To fully mitigate the risk, we should:
- Ensure `root` ends with a path separator (`/` or `\` as per OS), so that the containment check cannot be bypassed by prefix overlap.
- Use path normalization to ensure all comparisons are done on canonical paths.
- When checking containment, use direct comparison on the resolved, real paths—i.e., after resolving symlinks and normalizing both the root and the file path.
- For cross-platform robustness, utilize `path.sep` when appending separators.
- Fix the containment check to verify that `realPath` is strictly contained within `root`, by adding a separator at the end of the root path if missing, and ensuring that `realPath` starts with this canonicalized root path.

All changes are in tools/dev-server.mjs, specifically the definition of `root` and the containment check around line 31.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
